### PR TITLE
fix: add SPA catch-all rewrite to firebase.json for non-static frontends

### DIFF
--- a/.github/workflows/_frontend.yml
+++ b/.github/workflows/_frontend.yml
@@ -103,7 +103,8 @@ jobs:
           SITE_NAME="${{ inputs.site_id != '' && inputs.site_id || format('{0}-{1}', inputs.app_name, inputs.environment) }}"
           CLOUD_RUN_SERVICE="${{ inputs.app_name }}-${{ inputs.environment }}"
           if [ "${{ inputs.has_backend }}" = "true" ]; then
-            cat > firebase.json << EOF
+            if [ "${{ inputs.frontend_framework }}" = "static" ]; then
+              cat > firebase.json << EOF
           {
             "hosting": {
               "site": "${SITE_NAME}",
@@ -121,8 +122,33 @@ jobs:
             }
           }
           EOF
+            else
+              cat > firebase.json << EOF
+          {
+            "hosting": {
+              "site": "${SITE_NAME}",
+              "public": "${{ inputs.frontend_dir }}/dist",
+              "ignore": ["firebase.json", "**/.*", "**/node_modules/**"],
+              "rewrites": [
+                {
+                  "source": "/api/**",
+                  "run": {
+                    "serviceId": "${CLOUD_RUN_SERVICE}",
+                    "region": "${{ inputs.region }}"
+                  }
+                },
+                {
+                  "source": "**",
+                  "destination": "/index.html"
+                }
+              ]
+            }
+          }
+          EOF
+            fi
           else
-            cat > firebase.json << EOF
+            if [ "${{ inputs.frontend_framework }}" = "static" ]; then
+              cat > firebase.json << EOF
           {
             "hosting": {
               "site": "${SITE_NAME}",
@@ -131,6 +157,23 @@ jobs:
             }
           }
           EOF
+            else
+              cat > firebase.json << EOF
+          {
+            "hosting": {
+              "site": "${SITE_NAME}",
+              "public": "${{ inputs.frontend_dir }}/dist",
+              "ignore": ["firebase.json", "**/.*", "**/node_modules/**"],
+              "rewrites": [
+                {
+                  "source": "**",
+                  "destination": "/index.html"
+                }
+              ]
+            }
+          }
+          EOF
+            fi
           fi
 
       - name: Deploy to live channel


### PR DESCRIPTION
## Problem

All client-side routes (e.g. `/picks`, `/dashboard`) return 404 on Firebase Hosting because the generated `firebase.json` was missing the SPA catch-all rewrite rule.

## Root Cause

The `Create firebase.json` step in `_frontend.yml` only wrote an `/api/**` → Cloud Run rewrite (`has_backend=true`) or no rewrites at all (`has_backend=false`). Firebase Hosting returns 404 for any path that doesn't match a physical file in `dist/`.

## Fix

Restructured the step to add `{"source": "**", "destination": "/index.html"}` in all non-static branches:

- `has_backend=true` + non-static: API rewrite **+** SPA catch-all
- `has_backend=false` + non-static: SPA catch-all only
- Either + `frontend_framework=static`: unchanged (no SPA catch-all, preserves correct static site behaviour)

## Test plan

- [ ] Deploy Fantasy F1 via `workflow_dispatch` and verify `/picks` loads without 404
- [ ] Verify `/` still works
- [ ] Verify a `static` framework deploy is unaffected (no spurious rewrites)

🤖 Generated with [Claude Code](https://claude.com/claude-code)