### PR TITLE
feat: GCS storage bucket support

### DIFF
--- a/.github/workflows/_backend.yml
+++ b/.github/workflows/_backend.yml
@@ -46,6 +46,10 @@ on:
         type: string
         required: false
         default: ""
+      storage_bucket:
+        type: string
+        required: false
+        default: ""
     outputs:
       url:
         description: "Deployed backend URL"
@@ -106,13 +110,18 @@ jobs:
         run: |
           SERVICE_NAME="${{ inputs.app_name }}-${{ inputs.environment }}"
 
+          ENV_VARS="ENVIRONMENT=${{ inputs.environment }},APP_NAME=${{ inputs.app_name }},FRONTEND_URL=${{ inputs.frontend_url }}"
+          if [ -n "${{ inputs.storage_bucket }}" ]; then
+            ENV_VARS="${ENV_VARS},GCS_BUCKET=${{ inputs.storage_bucket }}"
+          fi
+
           gcloud run deploy "$SERVICE_NAME" \
             --image="$IMAGE" \
             --region=${{ inputs.region }} \
             --platform=managed \
             --allow-unauthenticated \
             --port=${{ inputs.backend_port }} \
-            --set-env-vars="ENVIRONMENT=${{ inputs.environment }},APP_NAME=${{ inputs.app_name }},FRONTEND_URL=${{ inputs.frontend_url }}" \
+            --set-env-vars="${ENV_VARS}" \
             --memory=${{ inputs.memory }} \
             --cpu=${{ inputs.cpu }} \
             --max-instances=10 \

--- a/.github/workflows/platform.yml
+++ b/.github/workflows/platform.yml
@@ -48,6 +48,8 @@ jobs:
       backend_changed: ${{ steps.changes.outputs.backend }}
       is_pr: ${{ github.event_name == 'pull_request' }}
       custom_domain: ${{ steps.config.outputs.custom_domain }}
+      has_storage: ${{ steps.config.outputs.has_storage }}
+      storage_type: ${{ steps.config.outputs.storage_type }}
 
     steps:
       - uses: actions/checkout@v4
@@ -86,6 +88,8 @@ jobs:
       frontend_url_prod: ${{ steps.tf-out-prod.outputs.frontend_url }}
       site_id_dev: ${{ steps.tf-out-dev.outputs.site_id }}
       site_id_prod: ${{ steps.tf-out-prod.outputs.site_id }}
+      storage_bucket_dev: ${{ steps.tf-out-dev.outputs.storage_bucket }}
+      storage_bucket_prod: ${{ steps.tf-out-prod.outputs.storage_bucket }}
     steps:
       - name: Checkout StackRamp platform
         uses: actions/checkout@v4
@@ -129,7 +133,8 @@ jobs:
             -var=region=${{ vars.STACKRAMP_REGION }} \
             -var=custom_domain=${CUSTOM_DOMAIN} \
             -var=backend_domain=${BACKEND_DOMAIN} \
-            -var=dns_zone_name=${{ vars.STACKRAMP_DNS_ZONE || '' }}"
+            -var=dns_zone_name=${{ vars.STACKRAMP_DNS_ZONE || '' }} \
+            -var=has_storage=${{ needs.parse-config.outputs.has_storage == 'true' }}"
 
           # Step 1: create Firebase custom domain first so required_dns_updates is populated
           if [ -n "$CUSTOM_DOMAIN" ]; then
@@ -145,6 +150,7 @@ jobs:
           echo "backend_url=$(terraform output -raw backend_url 2>/dev/null || echo '')" >> $GITHUB_OUTPUT
           echo "frontend_url=$(terraform output -raw frontend_url 2>/dev/null || echo '')" >> $GITHUB_OUTPUT
           echo "site_id=$(terraform output -raw site_id 2>/dev/null || echo '')" >> $GITHUB_OUTPUT
+          echo "storage_bucket=$(terraform output -raw storage_bucket 2>/dev/null || echo '')" >> $GITHUB_OUTPUT
 
       - name: Terraform init (prod)
         if: github.ref == 'refs/heads/main' && github.event_name == 'push'
@@ -168,7 +174,8 @@ jobs:
             -var=region=${{ vars.STACKRAMP_REGION }} \
             -var=custom_domain=${CUSTOM_DOMAIN} \
             -var=backend_domain=${BACKEND_DOMAIN} \
-            -var=dns_zone_name=${{ vars.STACKRAMP_DNS_ZONE || '' }}"
+            -var=dns_zone_name=${{ vars.STACKRAMP_DNS_ZONE || '' }} \
+            -var=has_storage=${{ needs.parse-config.outputs.has_storage == 'true' }}"
 
           if [ -n "$CUSTOM_DOMAIN" ]; then
             terraform apply -auto-approve -target=google_firebase_hosting_custom_domain.app $TF_VARS
@@ -183,6 +190,7 @@ jobs:
           echo "backend_url=$(terraform output -raw backend_url 2>/dev/null || echo '')" >> $GITHUB_OUTPUT
           echo "frontend_url=$(terraform output -raw frontend_url 2>/dev/null || echo '')" >> $GITHUB_OUTPUT
           echo "site_id=$(terraform output -raw site_id 2>/dev/null || echo '')" >> $GITHUB_OUTPUT
+          echo "storage_bucket=$(terraform output -raw storage_bucket 2>/dev/null || echo '')" >> $GITHUB_OUTPUT
 
   # ─────────────────────────────────────────────────────────────────────────────
   # 3. Deploy frontend (if changed)
@@ -231,6 +239,7 @@ jobs:
       wif_provider: ${{ vars.STACKRAMP_WIF_PROVIDER }}
       service_account: ${{ vars.STACKRAMP_SA_EMAIL }}
       frontend_url: ${{ needs.provision.outputs.frontend_url_dev }}
+      storage_bucket: ${{ needs.provision.outputs.storage_bucket_dev }}
 
   # ─────────────────────────────────────────────────────────────────────────────
   # 4. Deploy to PROD (main branch only, after dev succeeds)
@@ -280,3 +289,4 @@ jobs:
       wif_provider: ${{ vars.STACKRAMP_WIF_PROVIDER }}
       service_account: ${{ vars.STACKRAMP_SA_EMAIL }}
       frontend_url: ${{ needs.provision.outputs.frontend_url_prod }}
+      storage_bucket: ${{ needs.provision.outputs.storage_bucket_prod }}

--- a/docs/stackramp-yaml-reference.md
+++ b/docs/stackramp-yaml-reference.md
@@ -22,6 +22,8 @@ backend:
   cpu: "1"
 
 database: false
+
+storage: gcs       # optional — provisions a GCS bucket
 ```
 
 ## Fields
@@ -167,6 +169,33 @@ Whether the app needs a managed database. When enabled (Phase 2), the platform w
 1. Create a database on the shared Cloud SQL instance
 2. Generate and store credentials in Secret Manager
 3. Inject `DB_HOST`, `DB_PORT`, `DB_NAME`, `DB_USER`, `DB_PASSWORD` into the backend service
+
+---
+
+### `storage` (optional)
+
+| | |
+|---|---|
+| Type | `boolean` or `string` |
+| Values | `false`, `gcs` |
+| Default | `false` |
+
+Whether the app needs persistent object storage. When `gcs` is set:
+- A GCS bucket named `{app_name}-data-{environment}` is provisioned
+- The Cloud Run service account is granted `roles/storage.objectAdmin`
+- `GCS_BUCKET` env var is automatically injected into the backend service
+
+**Example:**
+```yaml
+name: my-app
+
+backend:
+  language: go
+  dir: backend
+  port: 8080
+
+storage: gcs
+```
 
 ---
 

--- a/platform-action/action.yml
+++ b/platform-action/action.yml
@@ -41,6 +41,12 @@ outputs:
   custom_domain:
     description: "Custom domain from stackramp.yaml, or {app_name}.{STACKRAMP_BASE_DOMAIN} if base domain is set"
     value: ${{ steps.parse.outputs.custom_domain }}
+  has_storage:
+    description: "Whether the app uses GCS storage"
+    value: ${{ steps.parse.outputs.has_storage }}
+  storage_type:
+    description: "Storage type (gcs or false)"
+    value: ${{ steps.parse.outputs.storage_type }}
 
 runs:
   using: "composite"
@@ -101,6 +107,15 @@ runs:
         HAS_DATABASE="false"
         [ "$DATABASE" != "false" ] && [ "$DATABASE" != "null" ] && HAS_DATABASE="true"
 
+        STORAGE=$(yq e '.storage // "false"' "$CONFIG")
+        if [ "$STORAGE" = "gcs" ]; then
+          HAS_STORAGE="true"
+          STORAGE_TYPE="gcs"
+        else
+          HAS_STORAGE="false"
+          STORAGE_TYPE="false"
+        fi
+
         echo "app_name=$APP_NAME" >> $GITHUB_OUTPUT
         echo "has_frontend=$HAS_FRONTEND" >> $GITHUB_OUTPUT
         echo "frontend_framework=$FRONTEND_FRAMEWORK" >> $GITHUB_OUTPUT
@@ -111,10 +126,13 @@ runs:
         echo "backend_port=$BACKEND_PORT" >> $GITHUB_OUTPUT
         echo "has_database=$HAS_DATABASE" >> $GITHUB_OUTPUT
         echo "provider=$PROVIDER" >> $GITHUB_OUTPUT
+        echo "has_storage=$HAS_STORAGE" >> $GITHUB_OUTPUT
+        echo "storage_type=$STORAGE_TYPE" >> $GITHUB_OUTPUT
         echo "custom_domain=$CUSTOM_DOMAIN" >> $GITHUB_OUTPUT
 
         echo "App: $APP_NAME"
         echo "Frontend: $FRONTEND_FRAMEWORK ($FRONTEND_DIR)"
         echo "Backend: $BACKEND_LANG ($BACKEND_DIR:$BACKEND_PORT)"
         echo "Database: $DATABASE"
+        echo "Storage: $STORAGE"
         echo "Provider: $PROVIDER"

--- a/providers/gcp/terraform/platform/main.tf
+++ b/providers/gcp/terraform/platform/main.tf
@@ -39,10 +39,10 @@ resource "google_firebase_hosting_site" "app" {
 # ── Custom Domain ─────────────────────────────────────────────────────────────
 
 resource "google_firebase_hosting_custom_domain" "app" {
-  count        = var.custom_domain != "" ? 1 : 0
-  provider     = google-beta
-  project      = var.platform_project
-  site_id      = google_firebase_hosting_site.app.site_id
+  count         = var.custom_domain != "" ? 1 : 0
+  provider      = google-beta
+  project       = var.platform_project
+  site_id       = google_firebase_hosting_site.app.site_id
   custom_domain = var.custom_domain
 }
 
@@ -54,7 +54,7 @@ resource "google_firebase_hosting_custom_domain" "app" {
 # first apply (TXT only) and subsequent applies (TXT + A) are both safe.
 
 locals {
-  dns_enabled  = var.custom_domain != "" && var.dns_zone_name != ""
+  dns_enabled = var.custom_domain != "" && var.dns_zone_name != ""
   # Apex domains (e.g. stackramp.io) cannot use CNAME — use A records.
   # Subdomains (e.g. guardian.stackramp.io) use CNAME to the Firebase site's
   # .web.app URL so Firebase can verify ownership and issue SSL automatically.
@@ -125,5 +125,35 @@ resource "google_cloud_run_v2_service_iam_member" "public" {
   name     = google_cloud_run_v2_service.app.name
   role     = "roles/run.invoker"
   member   = "allUsers"
+}
+
+# ── GCS Data Bucket (optional) ────────────────────────────────────────────────
+# When storage: gcs is declared in stackramp.yaml, provisions a persistent
+# data bucket and grants the Cloud Run service account access.
+
+data "google_project" "project" {
+  project_id = var.platform_project
+}
+
+resource "google_storage_bucket" "app_data" {
+  count         = var.has_storage ? 1 : 0
+  name          = "${var.app_name}-data-${var.environment}"
+  project       = var.platform_project
+  location      = var.region
+  force_destroy = false
+
+  uniform_bucket_level_access = true
+
+  lifecycle {
+    prevent_destroy = false
+  }
+}
+
+# Grant Cloud Run service account (default compute SA) objectAdmin on the bucket
+resource "google_storage_bucket_iam_member" "app_data_run" {
+  count  = var.has_storage ? 1 : 0
+  bucket = google_storage_bucket.app_data[0].name
+  role   = "roles/storage.objectAdmin"
+  member = "serviceAccount:${data.google_project.project.number}-compute@developer.gserviceaccount.com"
 }
 

--- a/providers/gcp/terraform/platform/outputs.tf
+++ b/providers/gcp/terraform/platform/outputs.tf
@@ -12,3 +12,8 @@ output "backend_url" {
   description = "Backend Cloud Run URI"
   value       = google_cloud_run_v2_service.app.uri
 }
+
+output "storage_bucket" {
+  description = "GCS bucket name for app data (empty if not enabled)"
+  value       = var.has_storage ? google_storage_bucket.app_data[0].name : ""
+}

--- a/providers/gcp/terraform/platform/variables.tf
+++ b/providers/gcp/terraform/platform/variables.tf
@@ -36,3 +36,9 @@ variable "backend_domain" {
   type        = string
   default     = ""
 }
+
+variable "has_storage" {
+  description = "Whether to provision a GCS bucket for this app"
+  type        = bool
+  default     = false
+}

--- a/stackramp.yaml.example
+++ b/stackramp.yaml.example
@@ -19,3 +19,5 @@ backend:
   cpu: "1"             # Cloud Run CPU (default: 1)
 
 database: false        # false | postgres | mysql (Phase 2)
+
+# storage: gcs         # false | gcs — provisions a GCS bucket + injects GCS_BUCKET env var


### PR DESCRIPTION
## Summary
- Adds `storage: gcs` option to stackramp.yaml
- When enabled, StackRamp provisions a GCS bucket (`{app_name}-data-{environment}`), grants Cloud Run `roles/storage.objectAdmin`, and injects `GCS_BUCKET` env var automatically

## Changes
- `platform-action/action.yml` — parse `storage` field, output `has_storage` + `storage_type`
- `providers/gcp/terraform/platform/main.tf` — `google_storage_bucket` + IAM binding
- `providers/gcp/terraform/platform/variables.tf` — `has_storage` variable
- `providers/gcp/terraform/platform/outputs.tf` — `storage_bucket` output
- `.github/workflows/platform.yml` — thread storage through provision → backend deploy
- `.github/workflows/_backend.yml` — conditionally add `GCS_BUCKET` to Cloud Run env vars
- `docs/stackramp-yaml-reference.md` — document the new field
- `stackramp.yaml.example` — add commented example

## Usage
```yaml
storage: gcs
```
That's it. StackRamp handles the rest.

## Test plan
- [ ] Verify `platform-action/action.yml` parses `storage: gcs` → `has_storage=true`
- [ ] Verify absent/false storage → `has_storage=false`
- [ ] Verify Terraform plan shows bucket + IAM when `has_storage=true`
- [ ] Verify Terraform plan shows no storage resources when `has_storage=false`
- [ ] Verify `GCS_BUCKET` env var appears in Cloud Run deploy command

🤖 Generated with [Claude Code](https://claude.com/claude-code)