### PR TITLE
feat: SSO via GCP IAP + HTTPS Load Balancer

### DIFF
--- a/.github/workflows/_backend.yml
+++ b/.github/workflows/_backend.yml
@@ -92,7 +92,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: bobbydeveaux/stackramp
-          ref: feat/sso-iap
+          ref: main
           path: .stackramp
 
       - name: Authenticate to Google Cloud

--- a/.github/workflows/_backend.yml
+++ b/.github/workflows/_backend.yml
@@ -65,6 +65,11 @@ on:
         required: false
         default: ""
         description: "Secret Manager secret ID holding DATABASE_URL for this app. Mounted directly into Cloud Run."
+      sso:
+        type: string
+        required: false
+        default: "false"
+        description: "When true, Cloud Run is deployed without --allow-unauthenticated (IAP LB is the entry point)."
     outputs:
       url:
         description: "Deployed backend URL"
@@ -134,6 +139,19 @@ jobs:
             ENV_VARS="${ENV_VARS},${{ inputs.extra_env_vars }}"
           fi
 
+          # ── .env file (backend/.env.{environment}) ───────────────────────────
+          # Convention: commit a .env.prod / .env.dev in your backend dir for
+          # non-sensitive config. Secret values belong in Secret Manager instead.
+          ENV_FILE="${{ inputs.backend_dir }}/.env.${{ inputs.environment }}"
+          if [ -f "$ENV_FILE" ]; then
+            echo "Loading env vars from $ENV_FILE"
+            while IFS= read -r line || [ -n "$line" ]; do
+              # skip blank lines and comments
+              [[ -z "$line" || "$line" == \#* ]] && continue
+              ENV_VARS="${ENV_VARS},${line}"
+            done < "$ENV_FILE"
+          fi
+
           # ── Secret refs (mounted by Cloud Run directly from Secret Manager) ─
           # Platform-wide secrets: any secret labelled platform-inject=true is
           # automatically discovered and mounted — no workflow changes needed
@@ -158,7 +176,6 @@ jobs:
             --image="$IMAGE"
             --region="${{ inputs.region }}"
             --platform=managed
-            --allow-unauthenticated
             --port="${{ inputs.backend_port }}"
             --set-env-vars="${ENV_VARS}"
             --memory="${{ inputs.memory }}"
@@ -169,6 +186,7 @@ jobs:
             --cpu-throttling
             --project="${{ inputs.platform_project }}"
           )
+          [ "${{ inputs.sso }}" = "true" ] && DEPLOY_FLAGS+=(--no-allow-unauthenticated) || DEPLOY_FLAGS+=(--allow-unauthenticated)
           [ -n "$SECRET_REFS" ] && DEPLOY_FLAGS+=(--set-secrets="$SECRET_REFS")
           [ -n "${{ inputs.cloudsql_connection_name }}" ] && DEPLOY_FLAGS+=(--add-cloudsql-instances="${{ inputs.cloudsql_connection_name }}")
 

--- a/.github/workflows/_backend.yml
+++ b/.github/workflows/_backend.yml
@@ -187,7 +187,12 @@ jobs:
             --cpu-throttling
             --project="${{ inputs.platform_project }}"
           )
-          [ "${{ inputs.sso }}" = "true" ] && DEPLOY_FLAGS+=(--no-allow-unauthenticated) || DEPLOY_FLAGS+=(--allow-unauthenticated)
+          # SSO: restrict ingress to LB only — IAP handles authn at the LB, no IAP SA grant needed
+          if [ "${{ inputs.sso }}" = "true" ]; then
+            DEPLOY_FLAGS+=(--allow-unauthenticated --ingress=internal-and-cloud-load-balancing)
+          else
+            DEPLOY_FLAGS+=(--allow-unauthenticated --ingress=all)
+          fi
           [ -n "$SECRET_REFS" ] && DEPLOY_FLAGS+=(--set-secrets="$SECRET_REFS")
           [ -n "${{ inputs.cloudsql_connection_name }}" ] && DEPLOY_FLAGS+=(--add-cloudsql-instances="${{ inputs.cloudsql_connection_name }}")
 

--- a/.github/workflows/_backend.yml
+++ b/.github/workflows/_backend.yml
@@ -92,6 +92,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: bobbydeveaux/stackramp
+          ref: feat/sso-iap
           path: .stackramp
 
       - name: Authenticate to Google Cloud

--- a/.github/workflows/_frontend.yml
+++ b/.github/workflows/_frontend.yml
@@ -46,6 +46,16 @@ on:
         type: string
         required: false
         default: ""
+      sso:
+        type: string
+        required: false
+        default: "false"
+        description: "When true, build a Docker image and deploy to Cloud Run instead of Firebase Hosting."
+      custom_domain:
+        type: string
+        required: false
+        default: ""
+        description: "Custom domain for the app — used as the output URL when sso=true."
     outputs:
       url:
         description: "Deployed frontend URL"
@@ -58,10 +68,10 @@ permissions:
 
 jobs:
   deploy:
-    name: Firebase Hosting
+    name: ${{ inputs.sso == 'true' && 'Cloud Run (SSO)' || 'Firebase Hosting' }}
     runs-on: ubuntu-latest
     outputs:
-      url: ${{ steps.deploy.outputs.url || steps.deploy-preview.outputs.url }}
+      url: ${{ steps.deploy.outputs.url || steps.deploy-preview.outputs.url || steps.deploy-sso.outputs.url }}
     steps:
       - uses: actions/checkout@v4
 
@@ -95,10 +105,43 @@ jobs:
           npm ci
           npm run build
 
+      # ── SSO path: Docker + Cloud Run ──────────────────────────────────────
+      - name: Configure Docker (SSO)
+        if: inputs.sso == 'true' && inputs.is_pr != 'true'
+        run: gcloud auth configure-docker ${{ inputs.region }}-docker.pkg.dev
+
+      - name: Build & push Docker image (SSO)
+        if: inputs.sso == 'true' && inputs.is_pr != 'true'
+        run: |
+          IMAGE="${{ inputs.region }}-docker.pkg.dev/${{ inputs.platform_project }}/stackramp-images/${{ inputs.app_name }}-fe:${{ github.sha }}"
+          docker build \
+            -t "$IMAGE" \
+            -f .stackramp/platform-action/dockerfiles/nginx-spa.Dockerfile \
+            ${{ inputs.frontend_dir }}/
+          docker push "$IMAGE"
+          echo "IMAGE=$IMAGE" >> $GITHUB_ENV
+
+      - name: Deploy to Cloud Run (SSO)
+        if: inputs.sso == 'true' && inputs.is_pr != 'true'
+        id: deploy-sso
+        run: |
+          gcloud run deploy "${{ inputs.app_name }}-fe-${{ inputs.environment }}" \
+            --image="$IMAGE" \
+            --region="${{ inputs.region }}" \
+            --platform=managed \
+            --port=8080 \
+            --no-allow-unauthenticated \
+            --project="${{ inputs.platform_project }}"
+          URL="${{ inputs.custom_domain != '' && format('https://{0}', inputs.custom_domain) || '' }}"
+          echo "url=$URL" >> $GITHUB_OUTPUT
+
+      # ── Firebase Hosting path (non-SSO) ───────────────────────────────────
       - name: Install Firebase Tools
+        if: inputs.sso != 'true'
         run: npm install -g firebase-tools
 
       - name: Create firebase.json
+        if: inputs.sso != 'true'
         run: |
           SITE_NAME="${{ inputs.site_id != '' && inputs.site_id || format('{0}-{1}', inputs.app_name, inputs.environment) }}"
           CLOUD_RUN_SERVICE="${{ inputs.app_name }}-${{ inputs.environment }}"
@@ -177,7 +220,7 @@ jobs:
           fi
 
       - name: Deploy to live channel
-        if: inputs.is_pr != 'true'
+        if: inputs.sso != 'true' && inputs.is_pr != 'true'
         id: deploy
         run: |
           firebase deploy --only hosting \
@@ -187,7 +230,7 @@ jobs:
           echo "url=${URL}" >> $GITHUB_OUTPUT
 
       - name: Deploy to preview channel
-        if: inputs.is_pr == 'true'
+        if: inputs.sso != 'true' && inputs.is_pr == 'true'
         id: deploy-preview
         run: |
           firebase hosting:channel:deploy pr-${{ github.event.pull_request.number }} \
@@ -198,7 +241,7 @@ jobs:
           echo "url=${URL}" >> $GITHUB_OUTPUT
 
       - name: Comment preview URL on PR
-        if: inputs.is_pr == 'true'
+        if: inputs.sso != 'true' && inputs.is_pr == 'true'
         uses: actions/github-script@v7
         with:
           script: |

--- a/.github/workflows/_frontend.yml
+++ b/.github/workflows/_frontend.yml
@@ -80,7 +80,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: bobbydeveaux/stackramp
-          ref: feat/sso-iap
+          ref: main
           path: .stackramp
 
       - name: Authenticate to Google Cloud

--- a/.github/workflows/_frontend.yml
+++ b/.github/workflows/_frontend.yml
@@ -75,6 +75,14 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Checkout StackRamp platform
+        if: inputs.sso == 'true'
+        uses: actions/checkout@v4
+        with:
+          repository: bobbydeveaux/stackramp
+          ref: feat/sso-iap
+          path: .stackramp
+
       - name: Authenticate to Google Cloud
         uses: bobbydeveaux/stackramp/providers/gcp/workflows/auth@main
         with:

--- a/.github/workflows/_frontend.yml
+++ b/.github/workflows/_frontend.yml
@@ -138,7 +138,8 @@ jobs:
             --region="${{ inputs.region }}" \
             --platform=managed \
             --port=8080 \
-            --no-allow-unauthenticated \
+            --allow-unauthenticated \
+            --ingress=internal-and-cloud-load-balancing \
             --project="${{ inputs.platform_project }}"
           URL="${{ inputs.custom_domain != '' && format('https://{0}', inputs.custom_domain) || '' }}"
           echo "url=$URL" >> $GITHUB_OUTPUT

--- a/.github/workflows/platform.yml
+++ b/.github/workflows/platform.yml
@@ -217,7 +217,7 @@ jobs:
     if: |
       needs.parse-config.outputs.has_frontend == 'true' &&
       (needs.parse-config.outputs.frontend_changed == 'true' || github.event_name == 'workflow_dispatch')
-    uses: bobbydeveaux/stackramp/.github/workflows/_frontend.yml@main
+    uses: bobbydeveaux/stackramp/.github/workflows/_frontend.yml@feat/sso-iap
     secrets: inherit
     with:
       app_name: ${{ needs.parse-config.outputs.app_name }}
@@ -244,7 +244,7 @@ jobs:
     if: |
       needs.parse-config.outputs.has_backend == 'true' &&
       (needs.parse-config.outputs.backend_changed == 'true' || github.event_name == 'workflow_dispatch')
-    uses: bobbydeveaux/stackramp/.github/workflows/_backend.yml@main
+    uses: bobbydeveaux/stackramp/.github/workflows/_backend.yml@feat/sso-iap
     secrets: inherit
     with:
       app_name: ${{ needs.parse-config.outputs.app_name }}
@@ -273,7 +273,7 @@ jobs:
       github.ref == 'refs/heads/main' && github.event_name == 'push' &&
       needs.parse-config.outputs.has_frontend == 'true' &&
       needs.deploy-frontend.result == 'success'
-    uses: bobbydeveaux/stackramp/.github/workflows/_frontend.yml@main
+    uses: bobbydeveaux/stackramp/.github/workflows/_frontend.yml@feat/sso-iap
     secrets: inherit
     with:
       app_name: ${{ needs.parse-config.outputs.app_name }}
@@ -299,7 +299,7 @@ jobs:
       github.ref == 'refs/heads/main' && github.event_name == 'push' &&
       needs.parse-config.outputs.has_backend == 'true' &&
       needs.deploy-backend.result == 'success'
-    uses: bobbydeveaux/stackramp/.github/workflows/_backend.yml@main
+    uses: bobbydeveaux/stackramp/.github/workflows/_backend.yml@feat/sso-iap
     secrets: inherit
     with:
       app_name: ${{ needs.parse-config.outputs.app_name }}

--- a/.github/workflows/platform.yml
+++ b/.github/workflows/platform.yml
@@ -59,7 +59,7 @@ jobs:
 
       - name: Parse config
         id: config
-        uses: bobbydeveaux/stackramp/platform-action@main
+        uses: bobbydeveaux/stackramp/platform-action@feat/sso-iap
         with:
           config_path: ${{ inputs.config_path }}
 

--- a/.github/workflows/platform.yml
+++ b/.github/workflows/platform.yml
@@ -59,7 +59,7 @@ jobs:
 
       - name: Parse config
         id: config
-        uses: bobbydeveaux/stackramp/platform-action@feat/sso-iap
+        uses: bobbydeveaux/stackramp/platform-action@main
         with:
           config_path: ${{ inputs.config_path }}
 
@@ -98,7 +98,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: bobbydeveaux/stackramp
-          ref: feat/sso-iap
+          ref: main
           path: .stackramp
 
       - name: Authenticate to Google Cloud
@@ -218,7 +218,7 @@ jobs:
     if: |
       needs.parse-config.outputs.has_frontend == 'true' &&
       (needs.parse-config.outputs.frontend_changed == 'true' || github.event_name == 'workflow_dispatch')
-    uses: bobbydeveaux/stackramp/.github/workflows/_frontend.yml@feat/sso-iap
+    uses: bobbydeveaux/stackramp/.github/workflows/_frontend.yml@main
     secrets: inherit
     with:
       app_name: ${{ needs.parse-config.outputs.app_name }}
@@ -245,7 +245,7 @@ jobs:
     if: |
       needs.parse-config.outputs.has_backend == 'true' &&
       (needs.parse-config.outputs.backend_changed == 'true' || github.event_name == 'workflow_dispatch')
-    uses: bobbydeveaux/stackramp/.github/workflows/_backend.yml@feat/sso-iap
+    uses: bobbydeveaux/stackramp/.github/workflows/_backend.yml@main
     secrets: inherit
     with:
       app_name: ${{ needs.parse-config.outputs.app_name }}
@@ -274,7 +274,7 @@ jobs:
       github.ref == 'refs/heads/main' && github.event_name == 'push' &&
       needs.parse-config.outputs.has_frontend == 'true' &&
       needs.deploy-frontend.result == 'success'
-    uses: bobbydeveaux/stackramp/.github/workflows/_frontend.yml@feat/sso-iap
+    uses: bobbydeveaux/stackramp/.github/workflows/_frontend.yml@main
     secrets: inherit
     with:
       app_name: ${{ needs.parse-config.outputs.app_name }}
@@ -300,7 +300,7 @@ jobs:
       github.ref == 'refs/heads/main' && github.event_name == 'push' &&
       needs.parse-config.outputs.has_backend == 'true' &&
       needs.deploy-backend.result == 'success'
-    uses: bobbydeveaux/stackramp/.github/workflows/_backend.yml@feat/sso-iap
+    uses: bobbydeveaux/stackramp/.github/workflows/_backend.yml@main
     secrets: inherit
     with:
       app_name: ${{ needs.parse-config.outputs.app_name }}

--- a/.github/workflows/platform.yml
+++ b/.github/workflows/platform.yml
@@ -50,6 +50,7 @@ jobs:
       custom_domain: ${{ steps.config.outputs.custom_domain }}
       has_storage: ${{ steps.config.outputs.has_storage }}
       storage_type: ${{ steps.config.outputs.storage_type }}
+      has_sso: ${{ steps.config.outputs.has_sso }}
 
     steps:
       - uses: actions/checkout@v4
@@ -129,6 +130,7 @@ jobs:
           BACKEND_DOMAIN=""
           [ -n "$CUSTOM_DOMAIN" ] && [ "${{ needs.parse-config.outputs.has_backend }}" = "true" ] && BACKEND_DOMAIN="api.${CUSTOM_DOMAIN}"
 
+          HAS_SSO="${{ needs.parse-config.outputs.has_sso }}"
           TF_VARS="-var=app_name=${{ needs.parse-config.outputs.app_name }} \
             -var=environment=dev \
             -var=platform_project=${{ vars.STACKRAMP_PROJECT }} \
@@ -138,13 +140,16 @@ jobs:
             -var=dns_zone_name=${{ vars.STACKRAMP_DNS_ZONE || '' }} \
             -var=has_storage=${{ needs.parse-config.outputs.has_storage == 'true' }} \
             -var=has_database=${{ needs.parse-config.outputs.has_database == 'true' }} \
-            -var=cloudsql_connection_name=${{ vars.STACKRAMP_CLOUDSQL_CONNECTION || '' }}"
+            -var=cloudsql_connection_name=${{ vars.STACKRAMP_CLOUDSQL_CONNECTION || '' }} \
+            -var=has_sso=${HAS_SSO} \
+            -var=iap_allowed_domain=${{ vars.STACKRAMP_IAP_DOMAIN || '' }}"
 
-          # Step 1: create Firebase custom domain first so required_dns_updates is populated
-          if [ -n "$CUSTOM_DOMAIN" ]; then
+          # For non-SSO apps with custom domains, create Firebase custom domain first
+          # so required_dns_updates is populated before the full apply.
+          if [ -n "$CUSTOM_DOMAIN" ] && [ "$HAS_SSO" != "true" ]; then
             terraform apply -auto-approve -target=google_firebase_hosting_custom_domain.app $TF_VARS
           fi
-          # Step 2: full apply — TXT records can now be created with known rrdatas
+          # Full apply
           terraform apply -auto-approve $TF_VARS
 
       - name: Capture dev outputs
@@ -173,6 +178,7 @@ jobs:
           BACKEND_DOMAIN=""
           [ -n "$CUSTOM_DOMAIN" ] && [ "${{ needs.parse-config.outputs.has_backend }}" = "true" ] && BACKEND_DOMAIN="api.${CUSTOM_DOMAIN}"
 
+          HAS_SSO="${{ needs.parse-config.outputs.has_sso }}"
           TF_VARS="-var=app_name=${{ needs.parse-config.outputs.app_name }} \
             -var=environment=prod \
             -var=platform_project=${{ vars.STACKRAMP_PROJECT }} \
@@ -182,9 +188,11 @@ jobs:
             -var=dns_zone_name=${{ vars.STACKRAMP_DNS_ZONE || '' }} \
             -var=has_storage=${{ needs.parse-config.outputs.has_storage == 'true' }} \
             -var=has_database=${{ needs.parse-config.outputs.has_database == 'true' }} \
-            -var=cloudsql_connection_name=${{ vars.STACKRAMP_CLOUDSQL_CONNECTION || '' }}"
+            -var=cloudsql_connection_name=${{ vars.STACKRAMP_CLOUDSQL_CONNECTION || '' }} \
+            -var=has_sso=${HAS_SSO} \
+            -var=iap_allowed_domain=${{ vars.STACKRAMP_IAP_DOMAIN || '' }}"
 
-          if [ -n "$CUSTOM_DOMAIN" ]; then
+          if [ -n "$CUSTOM_DOMAIN" ] && [ "$HAS_SSO" != "true" ]; then
             terraform apply -auto-approve -target=google_firebase_hosting_custom_domain.app $TF_VARS
           fi
           terraform apply -auto-approve $TF_VARS
@@ -224,6 +232,8 @@ jobs:
       has_backend: ${{ needs.parse-config.outputs.has_backend }}
       backend_url: ""
       site_id: ${{ needs.provision.outputs.site_id_dev }}
+      sso: ${{ needs.parse-config.outputs.has_sso }}
+      custom_domain: ${{ needs.parse-config.outputs.custom_domain }}
 
   # ─────────────────────────────────────────────────────────────────────────────
   # 3. Deploy backend (if changed)
@@ -250,6 +260,7 @@ jobs:
       storage_bucket: ${{ needs.provision.outputs.storage_bucket_dev }}
       cloudsql_connection_name: ${{ vars.STACKRAMP_CLOUDSQL_CONNECTION || '' }}
       database_secret_name: ${{ needs.provision.outputs.database_secret_name_dev }}
+      sso: ${{ needs.parse-config.outputs.has_sso }}
 
   # ─────────────────────────────────────────────────────────────────────────────
   # 4. Deploy to PROD (main branch only, after dev succeeds)
@@ -277,6 +288,8 @@ jobs:
       has_backend: ${{ needs.parse-config.outputs.has_backend }}
       backend_url: ""
       site_id: ${{ needs.provision.outputs.site_id_prod }}
+      sso: ${{ needs.parse-config.outputs.has_sso }}
+      custom_domain: ${{ needs.parse-config.outputs.custom_domain }}
 
   deploy-backend-prod:
     name: Backend → prod
@@ -302,3 +315,4 @@ jobs:
       storage_bucket: ${{ needs.provision.outputs.storage_bucket_prod }}
       cloudsql_connection_name: ${{ vars.STACKRAMP_CLOUDSQL_CONNECTION || '' }}
       database_secret_name: ${{ needs.provision.outputs.database_secret_name_prod }}
+      sso: ${{ needs.parse-config.outputs.has_sso }}

--- a/.github/workflows/platform.yml
+++ b/.github/workflows/platform.yml
@@ -98,6 +98,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: bobbydeveaux/stackramp
+          ref: feat/sso-iap
           path: .stackramp
 
       - name: Authenticate to Google Cloud

--- a/.github/workflows/platform.yml
+++ b/.github/workflows/platform.yml
@@ -107,6 +107,13 @@ jobs:
           wif_provider: ${{ vars.STACKRAMP_WIF_PROVIDER }}
           service_account: ${{ vars.STACKRAMP_SA_EMAIL }}
 
+      - name: Provision IAP service identity (SSO only)
+        if: needs.parse-config.outputs.has_sso == 'true'
+        run: |
+          gcloud beta services identity create \
+            --service=iap.googleapis.com \
+            --project=${{ vars.STACKRAMP_PROJECT }} 2>&1 || true
+
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v3
 

--- a/.github/workflows/platform.yml
+++ b/.github/workflows/platform.yml
@@ -107,13 +107,6 @@ jobs:
           wif_provider: ${{ vars.STACKRAMP_WIF_PROVIDER }}
           service_account: ${{ vars.STACKRAMP_SA_EMAIL }}
 
-      - name: Provision IAP service identity (SSO only)
-        if: needs.parse-config.outputs.has_sso == 'true'
-        run: |
-          gcloud beta services identity create \
-            --service=iap.googleapis.com \
-            --project=${{ vars.STACKRAMP_PROJECT }} 2>&1 || true
-
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v3
 

--- a/INTEGRATION.md
+++ b/INTEGRATION.md
@@ -1,0 +1,333 @@
+# StackRamp — Integration Guide
+
+StackRamp is a zero-config deployment platform for GCP. Add one config file and one workflow file to any repo and get Firebase Hosting (frontend) + Cloud Run (backend) with custom domains, preview URLs on PRs, and fully automated infra provisioning.
+
+---
+
+## Prerequisites
+
+A platform operator must run the bootstrap **once** before any apps can onboard. If you're onboarding an app into an existing StackRamp platform, skip to [Onboarding an App](#onboarding-an-app).
+
+---
+
+## Platform Bootstrap (one-time, operator only)
+
+The bootstrap provisions all shared GCP infrastructure: APIs, Artifact Registry, Firebase project, Workload Identity Federation, and optionally a Cloud DNS zone.
+
+```bash
+cd providers/gcp/terraform/bootstrap
+
+terraform init
+terraform apply \
+  -var=platform_project=YOUR_GCP_PROJECT_ID \
+  -var=github_owner=YOUR_GITHUB_ORG_OR_USERNAME \
+  -var=region=europe-west1 \
+  -var=base_domain=yourdomain.com   # optional — omit if not managing DNS via GCP
+```
+
+The `terraform output` after apply prints a summary of all GitHub Variables to set:
+
+| Variable | Description |
+|---|---|
+| `STACKRAMP_PROJECT` | GCP project ID |
+| `STACKRAMP_REGION` | GCP region (e.g. `europe-west1`) |
+| `STACKRAMP_WIF_PROVIDER` | Full Workload Identity provider resource name |
+| `STACKRAMP_SA_EMAIL` | Platform CI/CD service account email |
+| `STACKRAMP_DNS_ZONE` | Cloud DNS zone name (e.g. `yourdomain-com`) — only if `base_domain` was set |
+
+Set these as **GitHub Variables** (not secrets) at the organisation level: `Settings → Secrets and variables → Actions → Variables`. All repos in the org will inherit them automatically.
+
+> **DNS note:** if `base_domain` is set, the bootstrap creates a Cloud DNS managed zone. Point your domain's nameservers at the outputted nameservers at your registrar before deploying any apps with custom domains.
+
+---
+
+## Onboarding an App
+
+Two files in the app repo. That's it.
+
+### 1. `stackramp.yaml` (repo root)
+
+Describes what your app is. All fields except `name` are optional.
+
+```yaml
+name: my-app                  # required — lowercase slug, used for service names
+
+frontend:
+  framework: react            # react | vue | next | static | none
+  dir: frontend               # directory containing your frontend (default: frontend)
+  node_version: "20"          # node version, or use .nvmrc in frontend dir
+
+backend:
+  language: python            # python | go | node | none
+  dir: backend                # directory containing your backend (default: backend)
+  port: 8080                  # port your app listens on (default: 8080)
+  memory: 512Mi               # Cloud Run memory (default: 512Mi)
+  cpu: "1"                    # Cloud Run CPU (default: 1)
+
+domain: my-app.yourdomain.com # optional custom domain
+                              # omit for a .web.app Firebase URL
+
+database: false               # false | postgres | mysql (default: false)
+```
+
+**Frontend-only example:**
+```yaml
+name: guardian
+
+domain: guardian.yourdomain.com
+
+frontend:
+  framework: static
+  dir: website
+
+database: false
+```
+
+**Frontend + backend example:**
+```yaml
+name: my-api-app
+
+domain: my-api-app.yourdomain.com
+
+frontend:
+  framework: react
+  dir: frontend
+  node_version: "20"
+
+backend:
+  language: python
+  dir: backend
+  port: 8080
+
+database: false
+```
+
+---
+
+### 2. `.github/workflows/deploy.yml`
+
+```yaml
+name: Deploy
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    permissions:
+      id-token: write       # required for WIF / GCP auth
+      contents: read        # required to checkout code
+      pull-requests: write  # required to post PR preview URLs
+    uses: bobbydeveaux/stackramp/.github/workflows/platform.yml@main
+    secrets: inherit
+```
+
+That's the entire deploy workflow. No further configuration needed in the app repo.
+
+---
+
+## What Happens on Deploy
+
+```
+push to main / PR opened
+        │
+        ▼
+  parse-config
+  ┌─────────────────────────────────┐
+  │ Reads stackramp.yaml            │
+  │ Detects frontend/backend changes│
+  └─────────────────────────────────┘
+        │
+        ▼
+  provision (Terraform — idempotent)
+  ┌─────────────────────────────────┐
+  │ Firebase Hosting site           │
+  │ Custom domain + DNS CNAME       │
+  │ Cloud Run service shell         │
+  └─────────────────────────────────┘
+        │
+        ├──────────────────────────────────┐
+        ▼                                  ▼
+  deploy-frontend                    deploy-backend
+  ┌──────────────────────┐           ┌──────────────────────┐
+  │ npm ci + npm build   │           │ docker build + push  │
+  │ firebase deploy      │           │ gcloud run deploy    │
+  │ (or preview channel  │           └──────────────────────┘
+  │  if PR)              │
+  └──────────────────────┘
+        │
+        ▼ (main branch only, after dev succeeds)
+  deploy-frontend-prod + deploy-backend-prod
+```
+
+### Branch behaviour
+
+| Trigger | Environment | Frontend | Backend |
+|---|---|---|---|
+| `push` to `main` | `dev` then `prod` | Firebase live channel | Cloud Run |
+| Pull request | `preview` | Firebase preview channel | Cloud Run (preview env) |
+| `workflow_dispatch` | `dev` | Forces redeploy | Forces redeploy |
+
+### Change detection
+
+StackRamp uses `dorny/paths-filter` to skip unchanged components. If only the frontend changed, the backend job is skipped, and vice versa. `workflow_dispatch` bypasses this and redeploys everything.
+
+---
+
+## Custom Domains
+
+Set `domain:` in `stackramp.yaml`. StackRamp handles the rest automatically:
+
+- **Apex domain** (`yourdomain.com`): A records → Firebase's load balancer IPs
+- **Subdomain** (`app.yourdomain.com`): CNAME → `{site-id}.web.app` (Firebase verifies ownership via CNAME and mints SSL automatically)
+
+For `dev`, the subdomain is prefixed: `app.dev.yourdomain.com`. For `prod`, it uses the domain as-is.
+
+> **Requirement:** `STACKRAMP_DNS_ZONE` must be set as a GitHub Variable and the Cloud DNS zone must be authoritative for the domain (nameservers pointing to GCP).
+
+If you don't set `domain:`, your app gets a `{app-name}-{random}.web.app` Firebase URL.
+
+---
+
+## Backend: `/api` Routing
+
+When `has_backend: true`, Firebase Hosting rewrites all `/api/**` requests to Cloud Run. The frontend and backend share the same origin — no CORS configuration needed.
+
+```
+https://my-app.yourdomain.com/           → Firebase Hosting (frontend)
+https://my-app.yourdomain.com/api/...    → Cloud Run (backend)
+```
+
+The `VITE_API_URL` env var is set to the backend's Cloud Run URL at build time if needed for direct calls.
+
+---
+
+## Backend: Custom Dockerfile
+
+If your backend directory contains a `Dockerfile`, it is used as-is. Otherwise StackRamp uses a platform-provided Dockerfile for your language (`python`, `go`, or `node`).
+
+The following env vars are injected into every Cloud Run service at deploy time:
+
+| Variable | Value |
+|---|---|
+| `ENVIRONMENT` | `dev` or `prod` |
+| `APP_NAME` | Value of `name` in `stackramp.yaml` |
+| `FRONTEND_URL` | Firebase Hosting URL for the same environment |
+
+---
+
+## SSO via Google IAP
+
+Set `sso: true` on your frontend and/or backend to put the app behind Google Identity-Aware Proxy. Instead of Firebase Hosting, the frontend is served from Cloud Run (nginx) and both services sit behind a single HTTPS Global Load Balancer with IAP enforcing authentication.
+
+```yaml
+name: my-app
+
+domain: my-app.yourdomain.com
+
+frontend:
+  framework: react
+  sso: true
+
+backend:
+  language: python
+  sso: true
+```
+
+**What the platform provisions (SSO path):**
+
+```
+User → HTTPS LB (IAP) → /api/* → Cloud Run (backend)
+                      → /*     → Cloud Run (nginx, frontend SPA)
+```
+
+- Global HTTPS Load Balancer with managed SSL certificate
+- Identity-Aware Proxy on both backend services
+- Serverless NEGs routing LB traffic to Cloud Run
+- Cloud Run services restricted to `ingress: internal-and-cloud-load-balancing` (direct Cloud Run URLs are unreachable from the internet)
+- DNS A record for your custom domain pointing at the LB IP
+- Firebase Hosting is **not** used — frontend is nginx on Cloud Run
+
+**API calls from the frontend** use relative paths (`/api/...`) — no separate domain or CORS configuration needed since both frontend and backend are on the same domain.
+
+**Access control** is set via `STACKRAMP_IAP_DOMAIN` GitHub Variable:
+
+| Value | Who can access |
+|---|---|
+| `bobbyjason.co.uk` | Any Google account `@bobbyjason.co.uk` |
+| *(unset)* | Any authenticated Google account |
+
+**One-time operator setup:**
+1. Create an OAuth 2.0 Web Client in GCP Console → APIs & Services → Credentials
+2. Add `https://iap.googleapis.com/v1/oauth/clientIds/{CLIENT_ID}:handleRedirect` as an authorised redirect URI
+3. Store the client ID and secret in Secret Manager: `stackramp-iap-client-id` and `stackramp-iap-client-secret`
+4. Set `STACKRAMP_IAP_DOMAIN` as a GitHub Variable (optional — omit to allow all Google accounts)
+
+The bootstrap creates the Secret Manager shells and provisions the IAP service identity automatically. The OAuth client itself is created once in the GCP Console (Google deprecated the Terraform resource for this in 2025).
+
+**Toggling SSO off** is a clean operation — set `sso: false` and the platform destroys the LB/IAP resources and re-provisions Firebase Hosting automatically on the next push.
+
+---
+
+## Pull Request Previews
+
+On every PR:
+- Frontend is deployed to a Firebase **preview channel** (isolated, time-limited URL)
+- A comment is posted on the PR with the preview URL
+- Preview channels are scoped to `pr-{number}` and don't affect the live site
+
+---
+
+## GitHub Variables Reference
+
+Set at org level so all repos inherit them. None of these are secrets.
+
+| Variable | Example | Description |
+|---|---|---|
+| `STACKRAMP_PROJECT` | `my-platform-dev` | GCP project ID |
+| `STACKRAMP_REGION` | `europe-west1` | GCP region for all resources |
+| `STACKRAMP_WIF_PROVIDER` | `projects/123/locations/global/...` | Full WIF provider resource name (from bootstrap output) |
+| `STACKRAMP_SA_EMAIL` | `stackramp-cicd-sa@my-platform-dev.iam.gserviceaccount.com` | Platform CI/CD service account |
+| `STACKRAMP_DNS_ZONE` | `yourdomain-com` | Cloud DNS zone name — only needed for custom domains |
+| `STACKRAMP_IAP_DOMAIN` | `bobbyjason.co.uk` | Google Workspace domain allowed through IAP — only needed for SSO apps. Omit to allow any Google account. |
+
+---
+
+## Repo Structure (StackRamp platform repo)
+
+```
+stackramp/
+├── .github/workflows/
+│   ├── platform.yml          # Entry point — consuming repos reference this
+│   ├── _frontend.yml         # Reusable: Firebase Hosting deploy
+│   └── _backend.yml          # Reusable: Cloud Run build + deploy
+├── platform-action/
+│   ├── action.yml            # Parses stackramp.yaml, outputs config
+│   ├── schema.json           # stackramp.yaml JSON schema
+│   └── dockerfiles/
+│       ├── python.Dockerfile
+│       ├── node.Dockerfile
+│       └── go.Dockerfile
+└── providers/gcp/terraform/
+    ├── bootstrap/            # One-time platform setup
+    └── platform/             # Per-app infra (run on every deploy)
+```
+
+---
+
+## Troubleshooting
+
+**Deploy skipped (frontend/backend jobs not running)**
+The paths-filter detected no changes in the watched directories. Either push a real file change in `frontend/` or `backend/`, or trigger via `workflow_dispatch`.
+
+**Firebase domain stuck on "Needs setup" or "Minting certificate"**
+The CNAME record needs to propagate before Firebase can verify ownership. This typically takes a few minutes but can take longer. Check Cloud DNS has the correct CNAME pointing to `{site-id}.web.app` (not a hardcoded name). Firebase will automatically verify and mint the SSL cert once DNS propagates.
+
+**`Error 409: Resource already exists` on Cloud Run**
+A previous failed run partially created the service. Delete it manually: `gcloud run services delete {app-name}-{env} --region={region} --project={project}`, then re-trigger.
+
+**Firebase site ID globally reserved**
+Firebase site IDs are globally unique and held for 30 days after deletion. StackRamp appends a random suffix to all site IDs (e.g. `my-app-v9y8b-prod`) and uses `lifecycle { ignore_changes = [site_id] }` to prevent recreating existing sites. If you hit this, the suffix ensures a fresh ID is generated.

--- a/README.md
+++ b/README.md
@@ -35,12 +35,13 @@ name: my-app
 
 frontend:
   framework: react
+  sso: true         # optional — IAP-protected, served from Cloud Run
 
 backend:
   language: python
-  port: 8080
 
 database: false
+storage: gcs        # optional — provisions a GCS bucket
 ```
 
 ### Step 3: Add one workflow file
@@ -186,9 +187,12 @@ Custom `Dockerfile` in your backend directory is always supported as an override
 - [x] Default Dockerfiles (Python, Go, Node)
 - [x] Change detection (only deploy what changed)
 - [x] PR preview deployments
-- [ ] Database injection (Cloud SQL)
+- [x] Custom domain support (Cloud DNS, SSL auto-provisioned)
+- [x] GCS storage bucket support
+- [x] Cloud SQL (Postgres) with `DATABASE_URL` injected via Secret Manager
+- [x] Platform secrets auto-injected from Secret Manager (label-based)
+- [x] SSO via GCP IAP — Global HTTPS LB + Identity-Aware Proxy, opt-in per app
 - [ ] AWS provider
-- [ ] Custom domain support
 - [ ] Deploy status dashboard
 
 ## License

--- a/docs/stackramp-yaml-reference.md
+++ b/docs/stackramp-yaml-reference.md
@@ -13,17 +13,19 @@ frontend:
   framework: react
   dir: frontend
   node_version: "20"
+  sso: true          # optional — serve via Cloud Run + IAP (see SSO section)
 
 backend:
   language: python
   dir: backend
-  port: 8080
+  port: 8080         # optional — defaults to 8080
   memory: 512Mi
   cpu: "1"
+  sso: true          # optional — restrict to IAP-authenticated users
 
 database: false
 
-storage: gcs       # optional — provisions a GCS bucket
+storage: gcs         # optional — provisions a GCS bucket
 ```
 
 ## Fields
@@ -97,6 +99,15 @@ Directory containing your frontend source code, relative to repo root.
 
 Node.js version for building the frontend. Can also be set via `.nvmrc` in the frontend directory.
 
+#### `frontend.sso`
+
+| | |
+|---|---|
+| Type | `boolean` |
+| Default | `false` |
+
+When `true`, the frontend is served from Cloud Run (nginx) behind a Google IAP-protected HTTPS Load Balancer instead of Firebase Hosting. Requires `domain` to be set and the operator to have completed the [one-time IAP setup](../INTEGRATION.md#sso-via-google-iap).
+
 ---
 
 ### `backend` (optional)
@@ -136,6 +147,17 @@ Directory containing your backend source code, relative to repo root.
 | Default | `8080` |
 
 Port your backend application listens on.
+
+#### `backend.sso`
+
+| | |
+|---|---|
+| Type | `boolean` |
+| Default | `false` |
+
+When `true`, the backend Cloud Run service is placed behind the IAP load balancer and its ingress is restricted to the load balancer only. Direct Cloud Run URLs are inaccessible from the internet.
+
+Typically set together with `frontend.sso: true`. Access control is managed by the platform operator via `STACKRAMP_IAP_DOMAIN`.
 
 #### `backend.memory`
 

--- a/platform-action/action.yml
+++ b/platform-action/action.yml
@@ -47,6 +47,9 @@ outputs:
   storage_type:
     description: "Storage type (gcs or false)"
     value: ${{ steps.parse.outputs.storage_type }}
+  has_sso:
+    description: "Whether SSO (IAP) is enabled for this app"
+    value: ${{ steps.parse.outputs.has_sso }}
 
 runs:
   using: "composite"
@@ -116,6 +119,11 @@ runs:
           STORAGE_TYPE="false"
         fi
 
+        FRONTEND_SSO=$(yq '.frontend.sso // false' "$CONFIG")
+        BACKEND_SSO=$(yq '.backend.sso // false' "$CONFIG")
+        HAS_SSO="false"
+        { [ "$FRONTEND_SSO" = "true" ] || [ "$BACKEND_SSO" = "true" ]; } && HAS_SSO="true"
+
         echo "app_name=$APP_NAME" >> $GITHUB_OUTPUT
         echo "has_frontend=$HAS_FRONTEND" >> $GITHUB_OUTPUT
         echo "frontend_framework=$FRONTEND_FRAMEWORK" >> $GITHUB_OUTPUT
@@ -129,10 +137,12 @@ runs:
         echo "has_storage=$HAS_STORAGE" >> $GITHUB_OUTPUT
         echo "storage_type=$STORAGE_TYPE" >> $GITHUB_OUTPUT
         echo "custom_domain=$CUSTOM_DOMAIN" >> $GITHUB_OUTPUT
+        echo "has_sso=$HAS_SSO" >> $GITHUB_OUTPUT
 
         echo "App: $APP_NAME"
         echo "Frontend: $FRONTEND_FRAMEWORK ($FRONTEND_DIR)"
         echo "Backend: $BACKEND_LANG ($BACKEND_DIR:$BACKEND_PORT)"
         echo "Database: $DATABASE"
         echo "Storage: $STORAGE"
+        echo "SSO: $HAS_SSO"
         echo "Provider: $PROVIDER"

--- a/platform-action/dockerfiles/nginx-spa.Dockerfile
+++ b/platform-action/dockerfiles/nginx-spa.Dockerfile
@@ -1,0 +1,8 @@
+# Serves a pre-built Vite/React SPA from nginx on port 8080.
+# Build context must be the frontend directory (containing dist/ after npm run build).
+FROM nginx:alpine
+COPY dist /usr/share/nginx/html
+RUN echo 'server { listen 8080; root /usr/share/nginx/html; index index.html; location / { try_files $uri $uri/ /index.html; } }' \
+    > /etc/nginx/conf.d/default.conf
+EXPOSE 8080
+CMD ["nginx", "-g", "daemon off;"]

--- a/providers/gcp/terraform/bootstrap/bootstrap.sh
+++ b/providers/gcp/terraform/bootstrap/bootstrap.sh
@@ -180,6 +180,7 @@ print_info "Next steps:"
 echo "   1. Set these as GitHub Variables (org or repo → Settings → Actions → Variables):"
 echo
 BASE_DOMAIN=$(grep 'base_domain' "$TFVARS_FILE" | cut -d'"' -f2)
+IAP_DOMAIN=$(grep 'iap_allowed_domain' "$TFVARS_FILE" | grep -v '^#' | cut -d'"' -f2)
 terraform output -json | python3 -c "
 import json, sys
 data = json.load(sys.stdin)
@@ -195,6 +196,9 @@ if base_domain:
 cloudsql = data.get('cloudsql_connection_name', {}).get('value', '')
 if cloudsql:
     print(f'      STACKRAMP_CLOUDSQL_CONNECTION  = {cloudsql}')
+iap_domain = '${IAP_DOMAIN}'
+if iap_domain:
+    print(f'      STACKRAMP_IAP_DOMAIN           = {iap_domain}')
 ns = data.get('dns_zone_nameservers', {}).get('value', [])
 if ns:
     print()

--- a/providers/gcp/terraform/bootstrap/bootstrap.sh
+++ b/providers/gcp/terraform/bootstrap/bootstrap.sh
@@ -168,6 +168,15 @@ print_info "Applying..."
 terraform apply -var-file="$TFVARS_FILE" -auto-approve
 print_success "Bootstrap resources deployed!"
 
+# ── Provision IAP service identity ────────────────────────────────────────────
+# The IAP SA (service-PROJECT_NUMBER@gcp-sa-iap.iam.gserviceaccount.com) must
+# exist before any SSO app can deploy. Create it idempotently here.
+if grep -q 'iap_allowed_domain' "$TFVARS_FILE" 2>/dev/null; then
+  print_info "Provisioning IAP service identity..."
+  gcloud beta services identity create --service=iap.googleapis.com --project="$PROJECT_ID" 2>&1 | grep -v "already exists" || true
+  print_success "IAP service identity ready"
+fi
+
 # ── Outputs ───────────────────────────────────────────────────────────────────
 echo
 print_success "📤 Terraform outputs:"

--- a/providers/gcp/terraform/bootstrap/main.tf
+++ b/providers/gcp/terraform/bootstrap/main.tf
@@ -206,28 +206,18 @@ resource "google_service_account_iam_member" "wif_binding" {
   member             = "principalSet://iam.googleapis.com/${google_iam_workload_identity_pool.github.name}/attribute.repository_owner/${var.github_owner}"
 }
 
-# ── IAP Brand + Client ────────────────────────────────────────────────────────
-# One brand and one OAuth client per platform. Apps opt in via `sso: true` in
-# stackramp.yaml. The platform team controls access via iap_allowed_domain.
-# Note: Only one IAP brand is allowed per GCP project. If one already exists,
-# import it: terraform import google_iap_brand.platform projects/{project}/brands/{brand_id}
-
-resource "google_iap_brand" "platform" {
-  count             = var.iap_allowed_domain != "" ? 1 : 0
-  support_email     = var.iap_support_email
-  application_title = var.iap_application_title
-  project           = local.platform_project
-  depends_on        = [google_project_service.apis]
-}
-
-resource "google_iap_client" "platform" {
-  count        = var.iap_allowed_domain != "" ? 1 : 0
-  display_name = "StackRamp IAP"
-  brand        = google_iap_brand.platform[0].name
-}
-
-# Store IAP credentials in Secret Manager so platform terraform can read them
-# at app provision time without them ever appearing in workflow logs.
+# ── IAP Secret Manager shells ─────────────────────────────────────────────────
+# The IAP OAuth client is created manually in the GCP Console (APIs & Services
+# → Credentials → OAuth 2.0 Client IDs). The google_iap_brand / google_iap_client
+# Terraform resources are deprecated and shut down March 2026.
+#
+# After bootstrap apply:
+# 1. GCP Console → APIs & Services → OAuth consent screen — configure if needed
+# 2. GCP Console → APIs & Services → Credentials → Create OAuth 2.0 Client ID
+#    (Web application, add no redirect URIs — IAP manages them)
+# 3. Set the client ID and secret as secret versions in Secret Manager:
+#    stackramp-iap-client-id   ← paste client ID
+#    stackramp-iap-client-secret ← paste client secret
 
 resource "google_secret_manager_secret" "iap_client_id" {
   count     = var.iap_allowed_domain != "" ? 1 : 0
@@ -238,12 +228,6 @@ resource "google_secret_manager_secret" "iap_client_id" {
   depends_on = [google_project_service.apis]
 }
 
-resource "google_secret_manager_secret_version" "iap_client_id" {
-  count       = var.iap_allowed_domain != "" ? 1 : 0
-  secret      = google_secret_manager_secret.iap_client_id[0].id
-  secret_data = google_iap_client.platform[0].client_id
-}
-
 resource "google_secret_manager_secret" "iap_client_secret" {
   count     = var.iap_allowed_domain != "" ? 1 : 0
   secret_id = "stackramp-iap-client-secret"
@@ -251,12 +235,6 @@ resource "google_secret_manager_secret" "iap_client_secret" {
     auto {}
   }
   depends_on = [google_project_service.apis]
-}
-
-resource "google_secret_manager_secret_version" "iap_client_secret" {
-  count       = var.iap_allowed_domain != "" ? 1 : 0
-  secret      = google_secret_manager_secret.iap_client_secret[0].id
-  secret_data = google_iap_client.platform[0].client_secret
 }
 
 # Grant the CICD SA access to read IAP credentials during app provisioning

--- a/providers/gcp/terraform/bootstrap/main.tf
+++ b/providers/gcp/terraform/bootstrap/main.tf
@@ -46,6 +46,8 @@ resource "google_project_service" "apis" {
     "storage.googleapis.com",
     "cloudbuild.googleapis.com",
     "dns.googleapis.com",
+    "compute.googleapis.com",
+    "iap.googleapis.com",
   ])
 
   service            = each.value
@@ -91,6 +93,8 @@ resource "google_project_iam_member" "platform_roles" {
     "roles/cloudsql.admin",
     "roles/storage.admin",
     "roles/dns.admin",
+    "roles/compute.loadBalancerAdmin",
+    "roles/iap.admin",
   ])
 
   project = local.platform_project
@@ -200,4 +204,72 @@ resource "google_service_account_iam_member" "wif_binding" {
   service_account_id = google_service_account.platform_cicd.name
   role               = "roles/iam.workloadIdentityUser"
   member             = "principalSet://iam.googleapis.com/${google_iam_workload_identity_pool.github.name}/attribute.repository_owner/${var.github_owner}"
+}
+
+# ── IAP Brand + Client ────────────────────────────────────────────────────────
+# One brand and one OAuth client per platform. Apps opt in via `sso: true` in
+# stackramp.yaml. The platform team controls access via iap_allowed_domain.
+# Note: Only one IAP brand is allowed per GCP project. If one already exists,
+# import it: terraform import google_iap_brand.platform projects/{project}/brands/{brand_id}
+
+resource "google_iap_brand" "platform" {
+  count             = var.iap_allowed_domain != "" ? 1 : 0
+  support_email     = var.iap_support_email
+  application_title = var.iap_application_title
+  project           = local.platform_project
+  depends_on        = [google_project_service.apis]
+}
+
+resource "google_iap_client" "platform" {
+  count        = var.iap_allowed_domain != "" ? 1 : 0
+  display_name = "StackRamp IAP"
+  brand        = google_iap_brand.platform[0].name
+}
+
+# Store IAP credentials in Secret Manager so platform terraform can read them
+# at app provision time without them ever appearing in workflow logs.
+
+resource "google_secret_manager_secret" "iap_client_id" {
+  count     = var.iap_allowed_domain != "" ? 1 : 0
+  secret_id = "stackramp-iap-client-id"
+  replication {
+    auto {}
+  }
+  depends_on = [google_project_service.apis]
+}
+
+resource "google_secret_manager_secret_version" "iap_client_id" {
+  count       = var.iap_allowed_domain != "" ? 1 : 0
+  secret      = google_secret_manager_secret.iap_client_id[0].id
+  secret_data = google_iap_client.platform[0].client_id
+}
+
+resource "google_secret_manager_secret" "iap_client_secret" {
+  count     = var.iap_allowed_domain != "" ? 1 : 0
+  secret_id = "stackramp-iap-client-secret"
+  replication {
+    auto {}
+  }
+  depends_on = [google_project_service.apis]
+}
+
+resource "google_secret_manager_secret_version" "iap_client_secret" {
+  count       = var.iap_allowed_domain != "" ? 1 : 0
+  secret      = google_secret_manager_secret.iap_client_secret[0].id
+  secret_data = google_iap_client.platform[0].client_secret
+}
+
+# Grant the CICD SA access to read IAP credentials during app provisioning
+resource "google_secret_manager_secret_iam_member" "iap_client_id_access" {
+  count     = var.iap_allowed_domain != "" ? 1 : 0
+  secret_id = google_secret_manager_secret.iap_client_id[0].id
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${google_service_account.platform_cicd.email}"
+}
+
+resource "google_secret_manager_secret_iam_member" "iap_client_secret_access" {
+  count     = var.iap_allowed_domain != "" ? 1 : 0
+  secret_id = google_secret_manager_secret.iap_client_secret[0].id
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${google_service_account.platform_cicd.email}"
 }

--- a/providers/gcp/terraform/bootstrap/outputs.tf
+++ b/providers/gcp/terraform/bootstrap/outputs.tf
@@ -43,6 +43,11 @@ output "cloudsql_instance_name" {
   value       = var.enable_postgres ? google_sql_database_instance.platform[0].name : ""
 }
 
+output "iap_enabled" {
+  description = "Whether IAP was configured (iap_allowed_domain was set)"
+  value       = var.iap_allowed_domain != ""
+}
+
 output "github_variables_summary" {
   description = "Copy these values to your GitHub org/repo Variables"
   value = <<-EOT
@@ -59,6 +64,7 @@ output "github_variables_summary" {
     │ STACKRAMP_SA_EMAIL     = ${google_service_account.platform_cicd.email}
     ${var.base_domain != "" ? "│ STACKRAMP_BASE_DOMAIN  = ${var.base_domain}\n    │ STACKRAMP_DNS_ZONE     = ${replace(var.base_domain, ".", "-")}" : ""}
     ${var.enable_postgres ? "│ STACKRAMP_CLOUDSQL_CONNECTION = ${google_sql_database_instance.platform[0].connection_name}" : ""}
+    ${var.iap_allowed_domain != "" ? "│ STACKRAMP_IAP_DOMAIN          = ${var.iap_allowed_domain}" : ""}
     │                                                                    │
     └──────────────────────────────────────────────────────────────────────┘
 

--- a/providers/gcp/terraform/bootstrap/terraform.tfvars.example
+++ b/providers/gcp/terraform/bootstrap/terraform.tfvars.example
@@ -26,6 +26,7 @@ enable_postgres = false
 # or * for any authenticated Google account. Leave empty to skip IAP setup.
 # After apply, set STACKRAMP_IAP_DOMAIN as a GitHub Actions variable.
 # Note: Only one IAP brand is allowed per GCP project.
-iap_allowed_domain    = ""
-iap_support_email     = ""   # required when iap_allowed_domain is set
-# iap_application_title = "StackRamp"
+iap_allowed_domain = ""   # e.g. "yourcompany.com" or "*" for any Google account
+# After bootstrap apply, create an OAuth 2.0 client manually in GCP Console
+# (APIs & Services → Credentials) and set the client ID + secret as secret
+# versions in Secret Manager: stackramp-iap-client-id, stackramp-iap-client-secret

--- a/providers/gcp/terraform/bootstrap/terraform.tfvars.example
+++ b/providers/gcp/terraform/bootstrap/terraform.tfvars.example
@@ -20,3 +20,12 @@ platform_secrets = [
 # After apply, set STACKRAMP_CLOUDSQL_CONNECTION as a GitHub Actions variable.
 enable_postgres = false
 # postgres_tier = "db-f1-micro"
+
+# IAP (Identity-Aware Proxy) — enables sso: true support in stackramp.yaml.
+# Set iap_allowed_domain to your Google Workspace domain (e.g. yourcompany.com)
+# or * for any authenticated Google account. Leave empty to skip IAP setup.
+# After apply, set STACKRAMP_IAP_DOMAIN as a GitHub Actions variable.
+# Note: Only one IAP brand is allowed per GCP project.
+iap_allowed_domain    = ""
+iap_support_email     = ""   # required when iap_allowed_domain is set
+# iap_application_title = "StackRamp"

--- a/providers/gcp/terraform/bootstrap/variables.tf
+++ b/providers/gcp/terraform/bootstrap/variables.tf
@@ -62,14 +62,3 @@ variable "iap_allowed_domain" {
   default     = ""
 }
 
-variable "iap_support_email" {
-  description = "Support email shown on the IAP consent screen. Required when iap_allowed_domain is set."
-  type        = string
-  default     = ""
-}
-
-variable "iap_application_title" {
-  description = "Application title shown on the IAP consent screen."
-  type        = string
-  default     = "StackRamp"
-}

--- a/providers/gcp/terraform/bootstrap/variables.tf
+++ b/providers/gcp/terraform/bootstrap/variables.tf
@@ -55,3 +55,21 @@ variable "postgres_tier" {
   type        = string
   default     = "db-f1-micro"
 }
+
+variable "iap_allowed_domain" {
+  description = "Google Workspace domain whose members are granted IAP access (e.g. yourcompany.com). Use * for any Google account. Leave empty to skip IAP setup."
+  type        = string
+  default     = ""
+}
+
+variable "iap_support_email" {
+  description = "Support email shown on the IAP consent screen. Required when iap_allowed_domain is set."
+  type        = string
+  default     = ""
+}
+
+variable "iap_application_title" {
+  description = "Application title shown on the IAP consent screen."
+  type        = string
+  default     = "StackRamp"
+}

--- a/providers/gcp/terraform/platform/main.tf
+++ b/providers/gcp/terraform/platform/main.tf
@@ -85,7 +85,7 @@ locals {
   sso_dns_enabled = var.has_sso && var.custom_domain != "" && var.dns_zone_name != ""
 
   # IAP member — domain:example.com or allAuthenticatedUsers
-  iap_member = var.iap_allowed_domain == "*" ? "allAuthenticatedUsers" : "domain:${var.iap_allowed_domain}"
+  iap_member = (var.iap_allowed_domain == "" || var.iap_allowed_domain == "*") ? "allAuthenticatedUsers" : "domain:${var.iap_allowed_domain}"
 }
 
 # Apex domain: A records pointing at Firebase's stable load-balancer IPs

--- a/providers/gcp/terraform/platform/main.tf
+++ b/providers/gcp/terraform/platform/main.tf
@@ -1,3 +1,22 @@
+# ── State migrations ──────────────────────────────────────────────────────────
+# These handle existing apps deployed before count was added to these resources.
+# Safe to keep permanently — Terraform ignores moved blocks for new apps.
+
+moved {
+  from = google_firebase_hosting_site.app
+  to   = google_firebase_hosting_site.app[0]
+}
+
+moved {
+  from = random_string.site_suffix
+  to   = random_string.site_suffix[0]
+}
+
+moved {
+  from = google_cloud_run_v2_service_iam_member.public
+  to   = google_cloud_run_v2_service_iam_member.public[0]
+}
+
 # StackRamp Per-App Infrastructure
 # Run idempotently on every deploy to ensure app infra exists.
 # Creates Firebase Hosting site + Cloud Run service for the app.

--- a/providers/gcp/terraform/platform/main.tf
+++ b/providers/gcp/terraform/platform/main.tf
@@ -198,6 +198,25 @@ resource "google_cloud_run_v2_service_iam_member" "iap_frontend_invoker" {
   member   = "allUsers"
 }
 
+# IAP SA invoker on backend — IAP requires run.invoker even when Cloud Run allows allUsers
+resource "google_cloud_run_v2_service_iam_member" "iap_backend_invoker" {
+  count    = var.has_sso ? 1 : 0
+  project  = var.platform_project
+  location = var.region
+  name     = google_cloud_run_v2_service.app.name
+  role     = "roles/run.invoker"
+  member   = "serviceAccount:service-${data.google_project.project.number}@gcp-sa-iap.iam.gserviceaccount.com"
+}
+
+resource "google_cloud_run_v2_service_iam_member" "iap_frontend_invoker_sa" {
+  count    = var.has_sso ? 1 : 0
+  project  = var.platform_project
+  location = var.region
+  name     = google_cloud_run_v2_service.frontend_sso[0].name
+  role     = "roles/run.invoker"
+  member   = "serviceAccount:service-${data.google_project.project.number}@gcp-sa-iap.iam.gserviceaccount.com"
+}
+
 # Read IAP credentials from Secret Manager (created at bootstrap)
 data "google_secret_manager_secret_version" "iap_client_id" {
   count   = var.has_sso ? 1 : 0

--- a/providers/gcp/terraform/platform/main.tf
+++ b/providers/gcp/terraform/platform/main.tf
@@ -252,6 +252,7 @@ resource "google_compute_backend_service" "frontend_bs" {
   }
 
   iap {
+    enabled              = true
     oauth2_client_id     = data.google_secret_manager_secret_version.iap_client_id[0].secret_data
     oauth2_client_secret = data.google_secret_manager_secret_version.iap_client_secret[0].secret_data
   }
@@ -269,6 +270,7 @@ resource "google_compute_backend_service" "backend_bs" {
   }
 
   iap {
+    enabled              = true
     oauth2_client_id     = data.google_secret_manager_secret_version.iap_client_id[0].secret_data
     oauth2_client_secret = data.google_secret_manager_secret_version.iap_client_secret[0].secret_data
   }

--- a/providers/gcp/terraform/platform/main.tf
+++ b/providers/gcp/terraform/platform/main.tf
@@ -168,12 +168,18 @@ resource "google_cloud_run_v2_service" "frontend_sso" {
 
   template {
     containers {
-      image = "nginx:alpine"
+      image = "nginxinc/nginx-unprivileged:alpine"
       ports {
         container_port = 8080
       }
     }
+    # Only accept traffic from the HTTPS Load Balancer — IAP enforces authn there
+    scaling {
+      min_instance_count = 0
+    }
   }
+
+  ingress = "INGRESS_TRAFFIC_INTERNAL_LOAD_BALANCER"
 
   lifecycle {
     ignore_changes = [
@@ -182,24 +188,14 @@ resource "google_cloud_run_v2_service" "frontend_sso" {
   }
 }
 
-# IAP SA invoker on backend (replaces allUsers)
-resource "google_cloud_run_v2_service_iam_member" "iap_backend_invoker" {
-  count    = var.has_sso ? 1 : 0
-  project  = var.platform_project
-  location = var.region
-  name     = google_cloud_run_v2_service.app.name
-  role     = "roles/run.invoker"
-  member   = "serviceAccount:service-${data.google_project.project.number}@gcp-sa-iap.iam.gserviceaccount.com"
-}
-
-# IAP SA invoker on frontend
+# Allow unauthenticated invocations — security is enforced by LB ingress restriction + IAP
 resource "google_cloud_run_v2_service_iam_member" "iap_frontend_invoker" {
   count    = var.has_sso ? 1 : 0
   project  = var.platform_project
   location = var.region
   name     = google_cloud_run_v2_service.frontend_sso[0].name
   role     = "roles/run.invoker"
-  member   = "serviceAccount:service-${data.google_project.project.number}@gcp-sa-iap.iam.gserviceaccount.com"
+  member   = "allUsers"
 }
 
 # Read IAP credentials from Secret Manager (created at bootstrap)

--- a/providers/gcp/terraform/platform/main.tf
+++ b/providers/gcp/terraform/platform/main.tf
@@ -21,28 +21,30 @@ provider "random" {}
 # only new sites get the suffix stamped at first creation.
 
 resource "random_string" "site_suffix" {
+  count   = var.has_sso ? 0 : 1
   length  = 5
   special = false
   upper   = false
 }
 
 resource "google_firebase_hosting_site" "app" {
+  count    = var.has_sso ? 0 : 1
   provider = google-beta
   project  = var.platform_project
-  site_id  = "${var.app_name}-${random_string.site_suffix.result}-${var.environment}"
+  site_id  = "${var.app_name}-${random_string.site_suffix[0].result}-${var.environment}"
 
   lifecycle {
     ignore_changes = [site_id]
   }
 }
 
-# ── Custom Domain ─────────────────────────────────────────────────────────────
+# ── Custom Domain (Firebase Hosting, non-SSO only) ────────────────────────────
 
 resource "google_firebase_hosting_custom_domain" "app" {
-  count         = var.custom_domain != "" ? 1 : 0
+  count         = !var.has_sso && var.custom_domain != "" ? 1 : 0
   provider      = google-beta
   project       = var.platform_project
-  site_id       = google_firebase_hosting_site.app.site_id
+  site_id       = google_firebase_hosting_site.app[0].site_id
   custom_domain = var.custom_domain
 }
 
@@ -54,14 +56,17 @@ resource "google_firebase_hosting_custom_domain" "app" {
 # first apply (TXT only) and subsequent applies (TXT + A) are both safe.
 
 locals {
-  dns_enabled          = var.custom_domain != "" && var.dns_zone_name != ""
+  # Firebase DNS (non-SSO only)
+  dns_enabled          = !var.has_sso && var.custom_domain != "" && var.dns_zone_name != ""
   cloudsql_instance_id = var.has_database && var.cloudsql_connection_name != "" ? split(":", var.cloudsql_connection_name)[2] : ""
-  # Apex domains (e.g. stackramp.io) cannot use CNAME — use A records.
-  # Subdomains (e.g. guardian.stackramp.io) use CNAME to the Firebase site's
-  # .web.app URL so Firebase can verify ownership and issue SSL automatically.
-  is_subdomain = local.dns_enabled && length(split(".", var.custom_domain)) > 2
+  is_subdomain         = local.dns_enabled && length(split(".", var.custom_domain)) > 2
+  firebase_a_records   = ["199.36.158.100", "199.36.158.101"]
 
-  firebase_a_records = ["199.36.158.100", "199.36.158.101"]
+  # SSO DNS (points to LB static IP)
+  sso_dns_enabled = var.has_sso && var.custom_domain != "" && var.dns_zone_name != ""
+
+  # IAP member — domain:example.com or allAuthenticatedUsers
+  iap_member = var.iap_allowed_domain == "*" ? "allAuthenticatedUsers" : "domain:${var.iap_allowed_domain}"
 }
 
 # Apex domain: A records pointing at Firebase's stable load-balancer IPs
@@ -84,7 +89,7 @@ resource "google_dns_record_set" "frontend_cname" {
   ttl          = 300
   managed_zone = var.dns_zone_name
   project      = var.platform_project
-  rrdatas      = ["${google_firebase_hosting_site.app.site_id}.web.app."]
+  rrdatas      = ["${google_firebase_hosting_site.app[0].site_id}.web.app."]
 }
 
 # ── Cloud Run Service ─────────────────────────────────────────────────────────
@@ -119,13 +124,253 @@ resource "google_cloud_run_v2_service" "app" {
   }
 }
 
-# Allow unauthenticated access
+# Allow unauthenticated access (non-SSO apps only)
 resource "google_cloud_run_v2_service_iam_member" "public" {
+  count    = var.has_sso ? 0 : 1
   project  = var.platform_project
   location = var.region
   name     = google_cloud_run_v2_service.app.name
   role     = "roles/run.invoker"
   member   = "allUsers"
+}
+
+# ── SSO: IAP + HTTPS Load Balancer ───────────────────────────────────────────
+# When sso: true — frontend served from Cloud Run (not Firebase Hosting),
+# both services sit behind a single LB with IAP. The IAP OAuth client was
+# created once at bootstrap and its credentials are stored in Secret Manager.
+
+# Frontend Cloud Run service (serves nginx + built static files)
+resource "google_cloud_run_v2_service" "frontend_sso" {
+  count               = var.has_sso ? 1 : 0
+  name                = "${var.app_name}-fe-${var.environment}"
+  location            = var.region
+  project             = var.platform_project
+  deletion_protection = false
+
+  template {
+    containers {
+      image = "nginx:alpine"
+      ports {
+        container_port = 8080
+      }
+    }
+  }
+
+  lifecycle {
+    ignore_changes = [
+      template[0].containers[0].image,
+    ]
+  }
+}
+
+# IAP SA invoker on backend (replaces allUsers)
+resource "google_cloud_run_v2_service_iam_member" "iap_backend_invoker" {
+  count    = var.has_sso ? 1 : 0
+  project  = var.platform_project
+  location = var.region
+  name     = google_cloud_run_v2_service.app.name
+  role     = "roles/run.invoker"
+  member   = "serviceAccount:service-${data.google_project.project.number}@gcp-sa-iap.iam.gserviceaccount.com"
+}
+
+# IAP SA invoker on frontend
+resource "google_cloud_run_v2_service_iam_member" "iap_frontend_invoker" {
+  count    = var.has_sso ? 1 : 0
+  project  = var.platform_project
+  location = var.region
+  name     = google_cloud_run_v2_service.frontend_sso[0].name
+  role     = "roles/run.invoker"
+  member   = "serviceAccount:service-${data.google_project.project.number}@gcp-sa-iap.iam.gserviceaccount.com"
+}
+
+# Read IAP credentials from Secret Manager (created at bootstrap)
+data "google_secret_manager_secret_version" "iap_client_id" {
+  count   = var.has_sso ? 1 : 0
+  secret  = "stackramp-iap-client-id"
+  project = var.platform_project
+}
+
+data "google_secret_manager_secret_version" "iap_client_secret" {
+  count   = var.has_sso ? 1 : 0
+  secret  = "stackramp-iap-client-secret"
+  project = var.platform_project
+}
+
+# Static IP for the LB
+resource "google_compute_global_address" "app" {
+  count   = var.has_sso ? 1 : 0
+  name    = "${var.app_name}-${var.environment}-ip"
+  project = var.platform_project
+}
+
+# Managed SSL cert (provisioned automatically once DNS A record resolves)
+resource "google_compute_managed_ssl_certificate" "app" {
+  count   = var.has_sso && var.custom_domain != "" ? 1 : 0
+  name    = "${var.app_name}-${var.environment}-cert"
+  project = var.platform_project
+
+  managed {
+    domains = [var.custom_domain]
+  }
+}
+
+# Serverless NEGs
+resource "google_compute_region_network_endpoint_group" "frontend_neg" {
+  count                 = var.has_sso ? 1 : 0
+  name                  = "${var.app_name}-fe-${var.environment}-neg"
+  network_endpoint_type = "SERVERLESS"
+  region                = var.region
+  project               = var.platform_project
+
+  cloud_run {
+    service = google_cloud_run_v2_service.frontend_sso[0].name
+  }
+}
+
+resource "google_compute_region_network_endpoint_group" "backend_neg" {
+  count                 = var.has_sso ? 1 : 0
+  name                  = "${var.app_name}-be-${var.environment}-neg"
+  network_endpoint_type = "SERVERLESS"
+  region                = var.region
+  project               = var.platform_project
+
+  cloud_run {
+    service = google_cloud_run_v2_service.app.name
+  }
+}
+
+# Backend services with IAP enabled
+resource "google_compute_backend_service" "frontend_bs" {
+  count                 = var.has_sso ? 1 : 0
+  name                  = "${var.app_name}-fe-${var.environment}-bs"
+  project               = var.platform_project
+  protocol              = "HTTPS"
+  load_balancing_scheme = "EXTERNAL_MANAGED"
+
+  backend {
+    group = google_compute_region_network_endpoint_group.frontend_neg[0].id
+  }
+
+  iap {
+    oauth2_client_id     = data.google_secret_manager_secret_version.iap_client_id[0].secret_data
+    oauth2_client_secret = data.google_secret_manager_secret_version.iap_client_secret[0].secret_data
+  }
+}
+
+resource "google_compute_backend_service" "backend_bs" {
+  count                 = var.has_sso ? 1 : 0
+  name                  = "${var.app_name}-be-${var.environment}-bs"
+  project               = var.platform_project
+  protocol              = "HTTPS"
+  load_balancing_scheme = "EXTERNAL_MANAGED"
+
+  backend {
+    group = google_compute_region_network_endpoint_group.backend_neg[0].id
+  }
+
+  iap {
+    oauth2_client_id     = data.google_secret_manager_secret_version.iap_client_id[0].secret_data
+    oauth2_client_secret = data.google_secret_manager_secret_version.iap_client_secret[0].secret_data
+  }
+}
+
+# URL map: /api/* → backend, everything else → frontend
+resource "google_compute_url_map" "app" {
+  count           = var.has_sso ? 1 : 0
+  name            = "${var.app_name}-${var.environment}-urlmap"
+  project         = var.platform_project
+  default_service = google_compute_backend_service.frontend_bs[0].id
+
+  host_rule {
+    hosts        = var.custom_domain != "" ? [var.custom_domain] : ["*"]
+    path_matcher = "paths"
+  }
+
+  path_matcher {
+    name            = "paths"
+    default_service = google_compute_backend_service.frontend_bs[0].id
+
+    path_rule {
+      paths   = ["/api", "/api/*"]
+      service = google_compute_backend_service.backend_bs[0].id
+    }
+  }
+}
+
+# HTTP → HTTPS redirect
+resource "google_compute_url_map" "redirect" {
+  count   = var.has_sso ? 1 : 0
+  name    = "${var.app_name}-${var.environment}-redirect"
+  project = var.platform_project
+
+  default_url_redirect {
+    https_redirect = true
+    strip_query    = false
+  }
+}
+
+resource "google_compute_target_http_proxy" "redirect" {
+  count   = var.has_sso ? 1 : 0
+  name    = "${var.app_name}-${var.environment}-http-proxy"
+  project = var.platform_project
+  url_map = google_compute_url_map.redirect[0].id
+}
+
+resource "google_compute_global_forwarding_rule" "http_redirect" {
+  count                 = var.has_sso ? 1 : 0
+  name                  = "${var.app_name}-${var.environment}-http"
+  project               = var.platform_project
+  ip_address            = google_compute_global_address.app[0].address
+  port_range            = "80"
+  target                = google_compute_target_http_proxy.redirect[0].id
+  load_balancing_scheme = "EXTERNAL_MANAGED"
+}
+
+# HTTPS proxy + forwarding rule
+resource "google_compute_target_https_proxy" "app" {
+  count            = var.has_sso && var.custom_domain != "" ? 1 : 0
+  name             = "${var.app_name}-${var.environment}-https-proxy"
+  project          = var.platform_project
+  url_map          = google_compute_url_map.app[0].id
+  ssl_certificates = [google_compute_managed_ssl_certificate.app[0].id]
+}
+
+resource "google_compute_global_forwarding_rule" "https" {
+  count                 = var.has_sso && var.custom_domain != "" ? 1 : 0
+  name                  = "${var.app_name}-${var.environment}-https"
+  project               = var.platform_project
+  ip_address            = google_compute_global_address.app[0].address
+  port_range            = "443"
+  target                = google_compute_target_https_proxy.app[0].id
+  load_balancing_scheme = "EXTERNAL_MANAGED"
+}
+
+# DNS A record pointing to LB IP (SSO replaces Firebase DNS records)
+resource "google_dns_record_set" "sso_a" {
+  count        = local.sso_dns_enabled ? 1 : 0
+  name         = "${var.custom_domain}."
+  type         = "A"
+  ttl          = 300
+  managed_zone = var.dns_zone_name
+  project      = var.platform_project
+  rrdatas      = [google_compute_global_address.app[0].address]
+}
+
+# IAP access grants — who is allowed through the proxy
+resource "google_iap_web_backend_service_iam_member" "frontend_access" {
+  count               = var.has_sso ? 1 : 0
+  project             = var.platform_project
+  web_backend_service = google_compute_backend_service.frontend_bs[0].name
+  role                = "roles/iap.httpsResourceAccessor"
+  member              = local.iap_member
+}
+
+resource "google_iap_web_backend_service_iam_member" "backend_access" {
+  count               = var.has_sso ? 1 : 0
+  project             = var.platform_project
+  web_backend_service = google_compute_backend_service.backend_bs[0].name
+  role                = "roles/iap.httpsResourceAccessor"
+  member              = local.iap_member
 }
 
 # ── GCS Data Bucket (optional) ────────────────────────────────────────────────

--- a/providers/gcp/terraform/platform/outputs.tf
+++ b/providers/gcp/terraform/platform/outputs.tf
@@ -1,16 +1,25 @@
 output "site_id" {
-  description = "Firebase Hosting site ID (includes random suffix)"
-  value       = google_firebase_hosting_site.app.site_id
+  description = "Firebase Hosting site ID (empty when sso=true)"
+  value       = var.has_sso ? "" : google_firebase_hosting_site.app[0].site_id
 }
 
 output "frontend_url" {
-  description = "Frontend URL — custom domain if configured, otherwise Firebase .web.app URL"
-  value       = var.custom_domain != "" ? "https://${var.custom_domain}" : "https://${google_firebase_hosting_site.app.site_id}.web.app"
+  description = "Frontend URL"
+  value = var.has_sso ? (
+    var.custom_domain != "" ? "https://${var.custom_domain}" : "https://${google_cloud_run_v2_service.frontend_sso[0].uri}"
+  ) : (
+    var.custom_domain != "" ? "https://${var.custom_domain}" : "https://${google_firebase_hosting_site.app[0].site_id}.web.app"
+  )
 }
 
 output "backend_url" {
   description = "Backend Cloud Run URI"
   value       = google_cloud_run_v2_service.app.uri
+}
+
+output "lb_ip" {
+  description = "Load balancer static IP (only when sso=true)"
+  value       = var.has_sso ? google_compute_global_address.app[0].address : ""
 }
 
 output "storage_bucket" {

--- a/providers/gcp/terraform/platform/variables.tf
+++ b/providers/gcp/terraform/platform/variables.tf
@@ -54,3 +54,15 @@ variable "cloudsql_connection_name" {
   type        = string
   default     = ""
 }
+
+variable "has_sso" {
+  description = "Whether to enable IAP SSO for this app. Frontend is served from Cloud Run (not Firebase Hosting) and both services sit behind a GCP HTTPS Load Balancer with IAP."
+  type        = bool
+  default     = false
+}
+
+variable "iap_allowed_domain" {
+  description = "Google Workspace domain for IAP access (e.g. yourcompany.com). Use * for allAuthenticatedUsers. Sourced from STACKRAMP_IAP_DOMAIN."
+  type        = string
+  default     = ""
+}


### PR DESCRIPTION
## Summary

- Apps can opt in to SSO with `sso: true` on frontend/backend in `stackramp.yaml`
- Frontend served from Cloud Run (nginx SPA) instead of Firebase Hosting when SSO enabled
- Both frontend + backend sit behind a single HTTPS Global Load Balancer with IAP
- Single OAuth client per platform (created once at bootstrap, stored in Secret Manager)
- Access controlled via `STACKRAMP_IAP_DOMAIN` GitHub Variable (`domain:example.com` or `allAuthenticatedUsers` if unset)
- Cloud Run uses `--ingress=internal-and-cloud-load-balancing` + `--allow-unauthenticated` — IAP enforces authn at the LB
- IAP service identity auto-provisioned in `bootstrap.sh` (one-time per platform)
- `.env.{environment}` files in backend dir automatically loaded into Cloud Run env vars
- Backend `port` is now optional (defaults to 8080)

## Test plan

- [x] Deployed argus with `sso: true` on both frontend and backend
- [x] IAP login flow works end-to-end (`argus.dev.stackramp.io`)
- [x] Real frontend (Vite SPA via nginx) and backend (FastAPI) deployed and accessible
- [x] Non-SSO apps (arcade, guardian, etc.) unaffected — Firebase Hosting path unchanged
- [x] No `feat/sso-iap` branch references remain

🤖 Generated with [Claude Code](https://claude.com/claude-code)