### PR TITLE
feat: auto-generate Dockerfile for Rust backends

### DIFF
--- a/docs/stackramp-yaml-reference.md
+++ b/docs/stackramp-yaml-reference.md
@@ -119,7 +119,7 @@ Omit this block or set `language: none` if your app has no backend.
 | | |
 |---|---|
 | Type | `string` |
-| Values | `python`, `go`, `node`, `none` |
+| Values | `python`, `go`, `node`, `rust`, `none` |
 | Default | `none` |
 
 The backend language. Determines which default Dockerfile to use if you don't provide your own.
@@ -127,6 +127,7 @@ The backend language. Determines which default Dockerfile to use if you don't pr
 - `python` — uses `uvicorn` with `requirements.txt`
 - `go` — builds `cmd/server` or root package
 - `node` — runs `index.js` or `src/index.js`
+- `rust` — multi-stage build with `cargo build --release`, binary name parsed from `Cargo.toml`
 
 You can override the default by placing a `Dockerfile` in your backend directory.
 

--- a/platform-action/action.yml
+++ b/platform-action/action.yml
@@ -24,7 +24,7 @@ outputs:
     description: "Whether the app has a backend"
     value: ${{ steps.parse.outputs.has_backend }}
   backend_language:
-    description: "Backend language (python, go, node, none)"
+    description: "Backend language (python, go, node, rust, none)"
     value: ${{ steps.parse.outputs.backend_language }}
   backend_dir:
     description: "Backend directory"

--- a/platform-action/dockerfiles/rust.Dockerfile
+++ b/platform-action/dockerfiles/rust.Dockerfile
@@ -1,0 +1,32 @@
+# StackRamp default Rust Dockerfile
+# Multi-stage build for production-ready Rust apps
+
+FROM rust:1.77-bookworm AS builder
+
+WORKDIR /app
+
+# Cache dependency build: copy manifests first, build deps, then copy source
+COPY Cargo.toml Cargo.lock* ./
+RUN mkdir src && echo "fn main() {}" > src/main.rs && cargo build --release && rm -rf src
+
+COPY . .
+
+# Touch main.rs so cargo rebuilds the actual binary (not the dummy)
+RUN touch src/main.rs && cargo build --release
+
+# Parse binary name from Cargo.toml [package] name field
+RUN BINARY_NAME=$(grep -m1 '^name' Cargo.toml | sed 's/.*= *"//;s/".*//') && \
+    cp "/app/target/release/${BINARY_NAME}" /app/server
+
+# Stage 2: Runtime
+FROM debian:bookworm-slim
+
+RUN apt-get update && apt-get install -y ca-certificates && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+COPY --from=builder /app/server .
+
+ENV PORT=8080
+EXPOSE ${PORT}
+
+CMD ["/app/server"]

--- a/platform-action/schema.json
+++ b/platform-action/schema.json
@@ -33,7 +33,7 @@
       "properties": {
         "language": {
           "type": "string",
-          "enum": ["python", "go", "node", "none"],
+          "enum": ["python", "go", "node", "rust", "none"],
           "default": "none"
         },
         "dir": {

--- a/stackramp.yaml.example
+++ b/stackramp.yaml.example
@@ -12,7 +12,7 @@ frontend:
   node_version: "20"   # optional, defaults to 20 (or reads .nvmrc)
 
 backend:
-  language: python     # python | go | node | none
+  language: python     # python | go | node | rust | none
   dir: backend         # directory containing your backend code (default: backend)
   port: 8080           # port your app listens on (default: 8080)
   memory: 512Mi        # Cloud Run memory (default: 512Mi)


### PR DESCRIPTION
## Summary

- Add `language: rust` as a supported backend language in StackRamp
- Auto-generate a multi-stage Dockerfile: build with `rust:1.77-bookworm`, run on `debian:bookworm-slim`
- Parse binary name from `Cargo.toml` `[package] name` field automatically
- Include dependency caching layer (copy manifests first, build deps, then copy source) to speed up rebuilds
- Include `ca-certificates` in runtime image for TLS support

## Changes

- **`platform-action/dockerfiles/rust.Dockerfile`** — new multi-stage Dockerfile template
- **`platform-action/schema.json`** — add `rust` to `backend.language` enum
- **`platform-action/action.yml`** — update output description to include `rust`
- **`stackramp.yaml.example`** — update language comment
- **`docs/stackramp-yaml-reference.md`** — document `rust` language option

## Usage

```yaml
backend:
  language: rust
  dir: backend
  port: 8080
```

## Test plan

- [ ] Verify the Dockerfile builds a sample Rust project (e.g. Axum hello-world with `Cargo.toml`)
- [ ] Verify binary name is correctly parsed from `Cargo.toml` (including names with hyphens)
- [ ] Verify the schema validates `language: rust` without error
- [ ] Verify custom `Dockerfile` in backend dir still takes precedence (existing behavior)

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)