### PR TITLE
feat: cross-project IAM bindings in stackramp.yaml

### DIFF
--- a/.github/workflows/platform.yml
+++ b/.github/workflows/platform.yml
@@ -61,6 +61,7 @@ jobs:
       has_storage: ${{ steps.config.outputs.has_storage }}
       storage_type: ${{ steps.config.outputs.storage_type }}
       has_sso: ${{ steps.config.outputs.has_sso }}
+      iam_bindings: ${{ steps.config.outputs.iam_bindings }}
 
     steps:
       - uses: actions/checkout@v4
@@ -155,6 +156,12 @@ jobs:
             -var=has_sso=${HAS_SSO} \
             -var=iap_allowed_domain=${{ vars.STACKRAMP_IAP_DOMAIN || '' }}"
 
+          # Cross-project IAM bindings (JSON array from stackramp.yaml)
+          IAM_BINDINGS='${{ needs.parse-config.outputs.iam_bindings }}'
+          if [ "$IAM_BINDINGS" != "[]" ] && [ -n "$IAM_BINDINGS" ]; then
+            TF_VARS="$TF_VARS -var=iam_bindings=${IAM_BINDINGS}"
+          fi
+
           terraform apply -auto-approve $TF_VARS
 
       - name: Capture dev outputs
@@ -196,6 +203,12 @@ jobs:
             -var=cloudsql_connection_name=${{ vars.STACKRAMP_CLOUDSQL_CONNECTION || '' }} \
             -var=has_sso=${HAS_SSO} \
             -var=iap_allowed_domain=${{ vars.STACKRAMP_IAP_DOMAIN || '' }}"
+
+          # Cross-project IAM bindings (JSON array from stackramp.yaml)
+          IAM_BINDINGS='${{ needs.parse-config.outputs.iam_bindings }}'
+          if [ "$IAM_BINDINGS" != "[]" ] && [ -n "$IAM_BINDINGS" ]; then
+            TF_VARS="$TF_VARS -var=iam_bindings=${IAM_BINDINGS}"
+          fi
 
           terraform apply -auto-approve $TF_VARS
 

--- a/docs/stackramp-yaml-reference.md
+++ b/docs/stackramp-yaml-reference.md
@@ -177,6 +177,41 @@ Memory allocation for the backend service. Examples: `256Mi`, `512Mi`, `1Gi`, `2
 
 CPU allocation for the backend service. Examples: `1`, `2`, `4`.
 
+#### `backend.iam` (optional)
+
+| | |
+|---|---|
+| Type | `array` of objects |
+| Default | `[]` (no cross-project bindings) |
+
+Cross-project IAM bindings for the Cloud Run service account. Each entry grants an IAM role on a target GCP project or resource. This is useful when your backend needs to access resources in a different project (e.g. BigQuery datasets, Cloud Storage buckets).
+
+Each entry has the following fields:
+
+| Field | Required | Description |
+|---|---|---|
+| `role` | Yes | IAM role to grant (e.g. `roles/bigquery.dataViewer`, `roles/bigquery.jobUser`) |
+| `project` | Yes | Target GCP project ID |
+| `resource` | No | Resource path for resource-level bindings. Currently supports `datasets/{dataset_id}` for BigQuery dataset-level grants. Omit for project-level bindings. |
+
+**Prerequisites:** The deploying Workload Identity Federation (WIF) service account must have `roles/iam.securityAdmin` or equivalent on each target project.
+
+**Example:**
+```yaml
+name: my-api
+
+backend:
+  language: rust
+  dir: backend
+  port: 8080
+  iam:
+    - role: roles/bigquery.dataViewer
+      project: data-warehouse-prod
+      resource: datasets/analytics    # dataset-level binding
+    - role: roles/bigquery.jobUser
+      project: data-warehouse-prod    # project-level binding
+```
+
 ---
 
 ### `database`

--- a/platform-action/action.yml
+++ b/platform-action/action.yml
@@ -50,6 +50,9 @@ outputs:
   has_sso:
     description: "Whether SSO (IAP) is enabled for this app"
     value: ${{ steps.parse.outputs.has_sso }}
+  iam_bindings:
+    description: "JSON array of cross-project IAM bindings from backend.iam"
+    value: ${{ steps.parse.outputs.iam_bindings }}
 
 runs:
   using: "composite"
@@ -119,6 +122,14 @@ runs:
           STORAGE_TYPE="false"
         fi
 
+        # Cross-project IAM bindings
+        IAM_COUNT=$(yq '.backend.iam | length // 0' "$CONFIG")
+        if [ "$IAM_COUNT" -gt 0 ] && [ "$IAM_COUNT" != "null" ]; then
+          IAM_BINDINGS=$(yq -o=json -I=0 '.backend.iam' "$CONFIG")
+        else
+          IAM_BINDINGS="[]"
+        fi
+
         FRONTEND_SSO=$(yq '.frontend.sso // false' "$CONFIG")
         BACKEND_SSO=$(yq '.backend.sso // false' "$CONFIG")
         HAS_SSO="false"
@@ -138,6 +149,7 @@ runs:
         echo "storage_type=$STORAGE_TYPE" >> $GITHUB_OUTPUT
         echo "custom_domain=$CUSTOM_DOMAIN" >> $GITHUB_OUTPUT
         echo "has_sso=$HAS_SSO" >> $GITHUB_OUTPUT
+        echo "iam_bindings=$IAM_BINDINGS" >> $GITHUB_OUTPUT
 
         echo "App: $APP_NAME"
         echo "Frontend: $FRONTEND_FRAMEWORK ($FRONTEND_DIR)"
@@ -145,4 +157,5 @@ runs:
         echo "Database: $DATABASE"
         echo "Storage: $STORAGE"
         echo "SSO: $HAS_SSO"
+        echo "IAM bindings: $IAM_BINDINGS"
         echo "Provider: $PROVIDER"

--- a/platform-action/schema.json
+++ b/platform-action/schema.json
@@ -51,6 +51,30 @@
         "cpu": {
           "type": "string",
           "default": "1"
+        },
+        "iam": {
+          "type": "array",
+          "description": "Cross-project IAM bindings for the Cloud Run service account",
+          "items": {
+            "type": "object",
+            "required": ["role", "project"],
+            "properties": {
+              "role": {
+                "type": "string",
+                "description": "IAM role to grant (e.g. roles/bigquery.dataViewer)",
+                "pattern": "^roles/[a-zA-Z.]+$"
+              },
+              "project": {
+                "type": "string",
+                "description": "Target GCP project ID for the binding"
+              },
+              "resource": {
+                "type": "string",
+                "description": "Optional resource path for resource-level bindings (e.g. datasets/my_dataset for BigQuery dataset-level grants)"
+              }
+            },
+            "additionalProperties": false
+          }
         }
       }
     },

--- a/providers/gcp/terraform/platform/main.tf
+++ b/providers/gcp/terraform/platform/main.tf
@@ -497,3 +497,45 @@ resource "google_secret_manager_secret_iam_member" "database_url_run_access" {
   member    = "serviceAccount:${data.google_project.project.number}-compute@developer.gserviceaccount.com"
 }
 
+# ── Cross-Project IAM Bindings ────────────────────────────────────────────────
+# Grants the Cloud Run service account (default compute SA) IAM roles on
+# external projects or resources. Supports both project-level bindings
+# (google_project_iam_member) and BigQuery dataset-level bindings
+# (google_bigquery_dataset_iam_member).
+#
+# Prerequisite: the deploying WIF identity needs roles/iam.securityAdmin
+# (or equivalent) on each target project listed in the bindings.
+
+locals {
+  # Split bindings into project-level and dataset-level
+  iam_project_bindings = [
+    for b in var.iam_bindings : b if b.resource == ""
+  ]
+  iam_dataset_bindings = [
+    for b in var.iam_bindings : b if startswith(b.resource, "datasets/")
+  ]
+}
+
+resource "google_project_iam_member" "cross_project" {
+  for_each = {
+    for idx, b in local.iam_project_bindings :
+    "${b.project}--${b.role}" => b
+  }
+
+  project = each.value.project
+  role    = each.value.role
+  member  = "serviceAccount:${data.google_project.project.number}-compute@developer.gserviceaccount.com"
+}
+
+resource "google_bigquery_dataset_iam_member" "cross_project" {
+  for_each = {
+    for idx, b in local.iam_dataset_bindings :
+    "${b.project}--${b.resource}--${b.role}" => b
+  }
+
+  project    = each.value.project
+  dataset_id = trimprefix(each.value.resource, "datasets/")
+  role       = each.value.role
+  member     = "serviceAccount:${data.google_project.project.number}-compute@developer.gserviceaccount.com"
+}
+

--- a/providers/gcp/terraform/platform/variables.tf
+++ b/providers/gcp/terraform/platform/variables.tf
@@ -66,3 +66,13 @@ variable "iap_allowed_domain" {
   type        = string
   default     = ""
 }
+
+variable "iam_bindings" {
+  description = "Cross-project IAM bindings for the Cloud Run service account. Each entry grants a role on a target project, optionally scoped to a specific resource (e.g. BigQuery dataset)."
+  type = list(object({
+    role     = string
+    project  = string
+    resource = optional(string, "")
+  }))
+  default = []
+}

--- a/stackramp.yaml.example
+++ b/stackramp.yaml.example
@@ -21,3 +21,14 @@ backend:
 database: false        # false | postgres | mysql (Phase 2)
 
 # storage: gcs         # false | gcs — provisions a GCS bucket + injects GCS_BUCKET env var
+
+# Cross-project IAM bindings — grant the Cloud Run service account roles
+# on external projects (e.g. for BigQuery access in another project):
+#
+# backend:
+#   iam:
+#     - role: roles/bigquery.dataViewer
+#       project: other-project-id
+#       resource: datasets/my_dataset   # optional — omit for project-level
+#     - role: roles/bigquery.jobUser
+#       project: other-project-id


### PR DESCRIPTION
## Summary

- Adds `backend.iam` config block to `stackramp.yaml` for declaring cross-project IAM role bindings
- Supports **project-level** bindings via `google_project_iam_member` (e.g. `roles/bigquery.jobUser` on another project)
- Supports **BigQuery dataset-level** bindings via `google_bigquery_dataset_iam_member` (e.g. `roles/bigquery.dataViewer` on `datasets/forex_data`)
- Uses the Cloud Run default compute service account as the IAM member
- Parses IAM entries in the config action and passes them as a JSON variable to Terraform

## Example config

```yaml
backend:
  language: rust
  dir: backend
  port: 8080
  iam:
    - role: roles/bigquery.dataViewer
      project: slot-machine-dev
      resource: datasets/forex_data
    - role: roles/bigquery.jobUser
      project: slot-machine-dev
```

## Files changed

| File | Change |
|---|---|
| `platform-action/schema.json` | Added `iam` array schema under `backend` |
| `platform-action/action.yml` | Parse `backend.iam` entries, output as JSON |
| `.github/workflows/platform.yml` | Pass `iam_bindings` to Terraform apply (dev + prod) |
| `providers/gcp/terraform/platform/variables.tf` | New `iam_bindings` variable |
| `providers/gcp/terraform/platform/main.tf` | `google_project_iam_member` and `google_bigquery_dataset_iam_member` resources |
| `docs/stackramp-yaml-reference.md` | Document `backend.iam` field |
| `stackramp.yaml.example` | Add commented IAM example |

## Prerequisites

The deploying WIF service account needs `roles/iam.securityAdmin` (or equivalent) on each target project listed in the bindings. This is a one-time operator setup.

## Test plan

- [ ] Deploy an app with `backend.iam` entries and verify Terraform creates the expected IAM bindings
- [ ] Deploy an app without `backend.iam` and verify no IAM resources are created (empty default)
- [ ] Verify dataset-level bindings correctly parse `datasets/{name}` into `dataset_id`
- [ ] Verify project-level bindings (no `resource` field) create `google_project_iam_member`

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)