### PR TITLE
feat: support static frontend (no build step)

### DIFF
--- a/.github/workflows/_frontend.yml
+++ b/.github/workflows/_frontend.yml
@@ -56,6 +56,11 @@ on:
         required: false
         default: ""
         description: "Custom domain for the app — used as the output URL when sso=true."
+      frontend_spa:
+        type: string
+        required: false
+        default: "false"
+        description: "When 'true', adds SPA catch-all rewrite (all paths → index.html). Used with static framework."
     outputs:
       url:
         description: "Deployed frontend URL"
@@ -90,6 +95,7 @@ jobs:
           service_account: ${{ inputs.service_account }}
 
       - name: Detect Node version
+        if: inputs.frontend_framework != 'static'
         id: node-version
         run: |
           if [ -f "${{ inputs.frontend_dir }}/.nvmrc" ]; then
@@ -99,13 +105,21 @@ jobs:
           fi
 
       - name: Setup Node.js
+        if: inputs.frontend_framework != 'static'
         uses: actions/setup-node@v4
         with:
           node-version: ${{ steps.node-version.outputs.version }}
           cache: npm
           cache-dependency-path: "**/package-lock.json"
 
+      - name: Setup Node.js (static — for Firebase CLI only)
+        if: inputs.frontend_framework == 'static' && inputs.sso != 'true'
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
       - name: Install & Build
+        if: inputs.frontend_framework != 'static'
         env:
           VITE_API_URL: ${{ inputs.backend_url }}
         run: |
@@ -122,9 +136,17 @@ jobs:
         if: inputs.sso == 'true' && inputs.is_pr != 'true'
         run: |
           IMAGE="${{ inputs.region }}-docker.pkg.dev/${{ inputs.platform_project }}/stackramp-images/${{ inputs.app_name }}-fe:${{ github.sha }}"
+          if [ "${{ inputs.frontend_framework }}" = "static" ]; then
+            DOCKERFILE=".stackramp/platform-action/dockerfiles/nginx-static.Dockerfile"
+            BUILD_ARGS="--build-arg SPA=${{ inputs.frontend_spa }}"
+          else
+            DOCKERFILE=".stackramp/platform-action/dockerfiles/nginx-spa.Dockerfile"
+            BUILD_ARGS=""
+          fi
           docker build \
             -t "$IMAGE" \
-            -f .stackramp/platform-action/dockerfiles/nginx-spa.Dockerfile \
+            -f "$DOCKERFILE" \
+            $BUILD_ARGS \
             ${{ inputs.frontend_dir }}/
           docker push "$IMAGE"
           echo "IMAGE=$IMAGE" >> $GITHUB_ENV
@@ -154,32 +176,28 @@ jobs:
         run: |
           SITE_NAME="${{ inputs.site_id != '' && inputs.site_id || format('{0}-{1}', inputs.app_name, inputs.environment) }}"
           CLOUD_RUN_SERVICE="${{ inputs.app_name }}-${{ inputs.environment }}"
-          if [ "${{ inputs.has_backend }}" = "true" ]; then
-            if [ "${{ inputs.frontend_framework }}" = "static" ]; then
-              cat > firebase.json << EOF
+
+          # Static framework serves frontend_dir directly; built frameworks serve frontend_dir/dist
+          if [ "${{ inputs.frontend_framework }}" = "static" ]; then
+            PUBLIC_DIR="${{ inputs.frontend_dir }}"
+          else
+            PUBLIC_DIR="${{ inputs.frontend_dir }}/dist"
+          fi
+
+          # Determine whether to add SPA catch-all rewrite:
+          #   - Built frameworks (react/vue/next): always add SPA rewrite
+          #   - Static framework: only when frontend_spa is explicitly true
+          ADD_SPA="false"
+          if [ "${{ inputs.frontend_framework }}" != "static" ] || [ "${{ inputs.frontend_spa }}" = "true" ]; then
+            ADD_SPA="true"
+          fi
+
+          if [ "${{ inputs.has_backend }}" = "true" ] && [ "$ADD_SPA" = "true" ]; then
+            cat > firebase.json << EOF
           {
             "hosting": {
               "site": "${SITE_NAME}",
-              "public": "${{ inputs.frontend_dir }}/dist",
-              "ignore": ["firebase.json", "**/.*", "**/node_modules/**"],
-              "rewrites": [
-                {
-                  "source": "/api/**",
-                  "run": {
-                    "serviceId": "${CLOUD_RUN_SERVICE}",
-                    "region": "${{ inputs.region }}"
-                  }
-                }
-              ]
-            }
-          }
-          EOF
-            else
-              cat > firebase.json << EOF
-          {
-            "hosting": {
-              "site": "${SITE_NAME}",
-              "public": "${{ inputs.frontend_dir }}/dist",
+              "public": "${PUBLIC_DIR}",
               "ignore": ["firebase.json", "**/.*", "**/node_modules/**"],
               "rewrites": [
                 {
@@ -197,24 +215,31 @@ jobs:
             }
           }
           EOF
-            fi
-          else
-            if [ "${{ inputs.frontend_framework }}" = "static" ]; then
-              cat > firebase.json << EOF
+          elif [ "${{ inputs.has_backend }}" = "true" ]; then
+            cat > firebase.json << EOF
           {
             "hosting": {
               "site": "${SITE_NAME}",
-              "public": "${{ inputs.frontend_dir }}/dist",
-              "ignore": ["firebase.json", "**/.*", "**/node_modules/**"]
+              "public": "${PUBLIC_DIR}",
+              "ignore": ["firebase.json", "**/.*", "**/node_modules/**"],
+              "rewrites": [
+                {
+                  "source": "/api/**",
+                  "run": {
+                    "serviceId": "${CLOUD_RUN_SERVICE}",
+                    "region": "${{ inputs.region }}"
+                  }
+                }
+              ]
             }
           }
           EOF
-            else
-              cat > firebase.json << EOF
+          elif [ "$ADD_SPA" = "true" ]; then
+            cat > firebase.json << EOF
           {
             "hosting": {
               "site": "${SITE_NAME}",
-              "public": "${{ inputs.frontend_dir }}/dist",
+              "public": "${PUBLIC_DIR}",
               "ignore": ["firebase.json", "**/.*", "**/node_modules/**"],
               "rewrites": [
                 {
@@ -225,7 +250,16 @@ jobs:
             }
           }
           EOF
-            fi
+          else
+            cat > firebase.json << EOF
+          {
+            "hosting": {
+              "site": "${SITE_NAME}",
+              "public": "${PUBLIC_DIR}",
+              "ignore": ["firebase.json", "**/.*", "**/node_modules/**"]
+            }
+          }
+          EOF
           fi
 
       - name: Deploy to live channel

--- a/.github/workflows/platform.yml
+++ b/.github/workflows/platform.yml
@@ -61,6 +61,7 @@ jobs:
       has_storage: ${{ steps.config.outputs.has_storage }}
       storage_type: ${{ steps.config.outputs.storage_type }}
       has_sso: ${{ steps.config.outputs.has_sso }}
+      frontend_spa: ${{ steps.config.outputs.frontend_spa }}
 
     steps:
       - uses: actions/checkout@v4
@@ -239,6 +240,7 @@ jobs:
       site_id: ${{ needs.provision.outputs.site_id_dev }}
       sso: ${{ needs.parse-config.outputs.has_sso }}
       custom_domain: ${{ needs.parse-config.outputs.custom_domain }}
+      frontend_spa: ${{ needs.parse-config.outputs.frontend_spa }}
 
   # ─────────────────────────────────────────────────────────────────────────────
   # 3. Deploy backend (if changed)
@@ -296,6 +298,7 @@ jobs:
       site_id: ${{ needs.provision.outputs.site_id_prod }}
       sso: ${{ needs.parse-config.outputs.has_sso }}
       custom_domain: ${{ needs.parse-config.outputs.custom_domain }}
+      frontend_spa: ${{ needs.parse-config.outputs.frontend_spa }}
 
   deploy-backend-prod:
     name: Backend → prod

--- a/docs/stackramp-yaml-reference.md
+++ b/docs/stackramp-yaml-reference.md
@@ -10,9 +10,10 @@ name: my-app
 domain: my-app.io   # optional — explicit custom domain
 
 frontend:
-  framework: react
+  framework: react   # react | vue | next | static | none
   dir: frontend
   node_version: "20"
+  spa: false          # optional — SPA catch-all routing for static framework (default: false)
   sso: true          # optional — serve via Cloud Run + IAP (see SSO section)
 
 backend:
@@ -76,9 +77,9 @@ Omit this block or set `framework: none` if your app has no frontend.
 
 The frontend framework. Determines build commands and hosting configuration.
 
-- `react` / `vue` — standard SPA, built with `npm run build`
+- `react` / `vue` — standard SPA, built with `npm run build`, SPA catch-all routing enabled by default
 - `next` — Next.js app with SSR support
-- `static` — plain HTML/CSS/JS, no build step
+- `static` — plain HTML/CSS/JS, no build step (`npm install` / `npm run build` are skipped entirely, the contents of `dir` are deployed directly)
 - `none` — no frontend
 
 #### `frontend.dir`
@@ -98,6 +99,25 @@ Directory containing your frontend source code, relative to repo root.
 | Default | `20` |
 
 Node.js version for building the frontend. Can also be set via `.nvmrc` in the frontend directory.
+
+#### `frontend.spa`
+
+| | |
+|---|---|
+| Type | `boolean` |
+| Default | `false` |
+
+When `true` with `framework: static`, adds SPA catch-all routing so all paths serve `index.html`. This is useful for static single-page applications that handle routing client-side.
+
+For `react` and `vue` frameworks, SPA routing is always enabled regardless of this setting.
+
+**Example:**
+```yaml
+frontend:
+  framework: static
+  dir: frontend
+  spa: true
+```
 
 #### `frontend.sso`
 

--- a/platform-action/action.yml
+++ b/platform-action/action.yml
@@ -50,6 +50,9 @@ outputs:
   has_sso:
     description: "Whether SSO (IAP) is enabled for this app"
     value: ${{ steps.parse.outputs.has_sso }}
+  frontend_spa:
+    description: "Whether SPA catch-all routing is enabled (for static frontends)"
+    value: ${{ steps.parse.outputs.frontend_spa }}
 
 runs:
   using: "composite"
@@ -124,6 +127,9 @@ runs:
         HAS_SSO="false"
         { [ "$FRONTEND_SSO" = "true" ] || [ "$BACKEND_SSO" = "true" ]; } && HAS_SSO="true"
 
+        FRONTEND_SPA=$(yq '.frontend.spa // false' "$CONFIG")
+        [ "$FRONTEND_SPA" != "true" ] && FRONTEND_SPA="false"
+
         echo "app_name=$APP_NAME" >> $GITHUB_OUTPUT
         echo "has_frontend=$HAS_FRONTEND" >> $GITHUB_OUTPUT
         echo "frontend_framework=$FRONTEND_FRAMEWORK" >> $GITHUB_OUTPUT
@@ -138,6 +144,7 @@ runs:
         echo "storage_type=$STORAGE_TYPE" >> $GITHUB_OUTPUT
         echo "custom_domain=$CUSTOM_DOMAIN" >> $GITHUB_OUTPUT
         echo "has_sso=$HAS_SSO" >> $GITHUB_OUTPUT
+        echo "frontend_spa=$FRONTEND_SPA" >> $GITHUB_OUTPUT
 
         echo "App: $APP_NAME"
         echo "Frontend: $FRONTEND_FRAMEWORK ($FRONTEND_DIR)"

--- a/platform-action/dockerfiles/nginx-static.Dockerfile
+++ b/platform-action/dockerfiles/nginx-static.Dockerfile
@@ -1,0 +1,15 @@
+# Serves a static frontend (no build step) from nginx on port 8080.
+# Build context must be the frontend directory (containing index.html and static assets).
+# Pass --build-arg SPA=true to enable SPA catch-all routing (all paths → index.html).
+FROM nginx:alpine
+ARG SPA=false
+COPY . /usr/share/nginx/html
+RUN if [ "$SPA" = "true" ]; then \
+      echo 'server { listen 8080; root /usr/share/nginx/html; index index.html; location / { try_files $uri $uri/ /index.html; } }' \
+        > /etc/nginx/conf.d/default.conf; \
+    else \
+      echo 'server { listen 8080; root /usr/share/nginx/html; index index.html; }' \
+        > /etc/nginx/conf.d/default.conf; \
+    fi
+EXPOSE 8080
+CMD ["nginx", "-g", "daemon off;"]

--- a/platform-action/schema.json
+++ b/platform-action/schema.json
@@ -25,6 +25,11 @@
         "node_version": {
           "type": "string",
           "default": "20"
+        },
+        "spa": {
+          "type": "boolean",
+          "default": false,
+          "description": "When true with framework: static, adds SPA catch-all rewrite (all paths → index.html)."
         }
       }
     },

--- a/stackramp.yaml.example
+++ b/stackramp.yaml.example
@@ -10,6 +10,7 @@ frontend:
   framework: react     # react | vue | next | static | none
   dir: frontend        # directory containing your frontend code (default: frontend)
   node_version: "20"   # optional, defaults to 20 (or reads .nvmrc)
+  # spa: true          # optional — SPA catch-all routing for static framework (default: false)
 
 backend:
   language: python     # python | go | node | none


### PR DESCRIPTION
## Summary

- When `frontend.framework: static` in `stackramp.yaml`, skip `npm install` / `npm run build` entirely and deploy the contents of `frontend.dir` directly to Firebase Hosting
- SPA catch-all routing is opt-in for static frontends via `frontend.spa: true` (built frameworks like react/vue/next get SPA routing by default, as before)
- Added `nginx-static.Dockerfile` for the SSO/Cloud Run path, with optional SPA support via build arg

## Changes

- **`.github/workflows/_frontend.yml`** — conditionally skip Node setup + build for `static` framework; use `frontend_dir` (not `frontend_dir/dist`) as Firebase public directory; new `frontend_spa` input controls SPA rewrite
- **`.github/workflows/platform.yml`** — thread `frontend_spa` output from config parser to frontend deploy jobs
- **`platform-action/action.yml`** — parse `frontend.spa` from `stackramp.yaml` and expose as output
- **`platform-action/schema.json`** — add `spa` boolean property to frontend schema
- **`platform-action/dockerfiles/nginx-static.Dockerfile`** — new Dockerfile for SSO path with static frontends
- **`docs/stackramp-yaml-reference.md`** — document `frontend.spa` field and static framework behaviour
- **`stackramp.yaml.example`** — show `spa` option in example config

## Example config

```yaml
name: my-app

frontend:
  framework: static
  dir: frontend
  spa: true           # optional — enables SPA catch-all routing
```

## Test plan

- [ ] Deploy a static frontend (single `index.html`, no `package.json`) with `framework: static` — verify no npm commands run and the file is served
- [ ] Verify `spa: true` adds the catch-all rewrite in firebase.json
- [ ] Verify `spa: false` (or omitted) does NOT add the catch-all rewrite for static
- [ ] Verify existing `react`/`vue` frontends still get SPA routing by default (no regression)
- [ ] Verify SSO path uses `nginx-static.Dockerfile` for static framework

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)