### PR TITLE
feat: support multiple backend services in stackramp.yaml

### DIFF
--- a/.github/workflows/_backend.yml
+++ b/.github/workflows/_backend.yml
@@ -6,6 +6,11 @@ on:
       app_name:
         type: string
         required: true
+      service_name:
+        type: string
+        required: false
+        default: ""
+        description: "Backend service name (for multi-backend apps). Empty = use app_name as the Cloud Run service name."
       backend_dir:
         type: string
         required: true
@@ -54,7 +59,7 @@ on:
         type: string
         required: false
         default: ""
-        description: "Additional comma-separated KEY=VALUE env vars to inject into Cloud Run (non-secret config only)."
+        description: "Additional comma-separated KEY=VALUE env vars to inject into Cloud Run (non-secret config only). Used for service discovery URLs."
       cloudsql_connection_name:
         type: string
         required: false
@@ -109,7 +114,12 @@ jobs:
 
       - name: Build Docker image
         run: |
-          IMAGE="${{ inputs.region }}-docker.pkg.dev/${{ inputs.platform_project }}/stackramp-images/${{ inputs.app_name }}:${{ github.sha }}"
+          # For multi-backend apps, tag images per service; for single backend, use app_name
+          if [ -n "${{ inputs.service_name }}" ]; then
+            IMAGE="${{ inputs.region }}-docker.pkg.dev/${{ inputs.platform_project }}/stackramp-images/${{ inputs.app_name }}-${{ inputs.service_name }}:${{ github.sha }}"
+          else
+            IMAGE="${{ inputs.region }}-docker.pkg.dev/${{ inputs.platform_project }}/stackramp-images/${{ inputs.app_name }}:${{ github.sha }}"
+          fi
 
           if [ -f "${{ inputs.backend_dir }}/Dockerfile" ]; then
             echo "Using custom Dockerfile from ${{ inputs.backend_dir }}/Dockerfile"
@@ -129,7 +139,12 @@ jobs:
 
       - name: Deploy to Cloud Run
         run: |
-          SERVICE_NAME="${{ inputs.app_name }}-${{ inputs.environment }}"
+          # For multi-backend apps, include service name; for single backend, use app_name
+          if [ -n "${{ inputs.service_name }}" ]; then
+            SERVICE_NAME="${{ inputs.app_name }}-${{ inputs.service_name }}-${{ inputs.environment }}"
+          else
+            SERVICE_NAME="${{ inputs.app_name }}-${{ inputs.environment }}"
+          fi
 
           # ── Env vars (non-secret config) ────────────────────────────────────
           ENV_VARS="ENVIRONMENT=${{ inputs.environment }},APP_NAME=${{ inputs.app_name }},FRONTEND_URL=${{ inputs.frontend_url }}"
@@ -201,7 +216,11 @@ jobs:
       - name: Get deployed URL
         id: url
         run: |
-          SERVICE_NAME="${{ inputs.app_name }}-${{ inputs.environment }}"
+          if [ -n "${{ inputs.service_name }}" ]; then
+            SERVICE_NAME="${{ inputs.app_name }}-${{ inputs.service_name }}-${{ inputs.environment }}"
+          else
+            SERVICE_NAME="${{ inputs.app_name }}-${{ inputs.environment }}"
+          fi
           URL=$(gcloud run services describe "$SERVICE_NAME" \
             --region=${{ inputs.region }} \
             --project=${{ inputs.platform_project }} \

--- a/.github/workflows/_cleanup-preview.yml
+++ b/.github/workflows/_cleanup-preview.yml
@@ -46,11 +46,23 @@ jobs:
           PR_NUM="${{ github.event.number }}"
           ENV="pr-${PR_NUM}"
 
-          # Delete backend preview service (if it exists)
+          # Delete backend preview service (if it exists) — single backend mode
           if gcloud run services describe "${APP_NAME}-${ENV}" --region="$REGION" --project="$PROJECT" 2>/dev/null; then
             echo "Deleting backend preview: ${APP_NAME}-${ENV}"
             gcloud run services delete "${APP_NAME}-${ENV}" --region="$REGION" --project="$PROJECT" --quiet
           fi
+
+          # Delete multi-backend preview services (if they exist)
+          # List all Cloud Run services matching the app name pattern for this PR
+          MULTI_SERVICES=$(gcloud run services list \
+            --region="$REGION" \
+            --project="$PROJECT" \
+            --filter="metadata.name~'^${APP_NAME}-.*-${ENV}$'" \
+            --format="value(metadata.name)" 2>/dev/null || true)
+          for SVC in $MULTI_SERVICES; do
+            echo "Deleting multi-backend preview: $SVC"
+            gcloud run services delete "$SVC" --region="$REGION" --project="$PROJECT" --quiet
+          done
 
           # Delete frontend SSO preview service (if it exists)
           if gcloud run services describe "${APP_NAME}-fe-${ENV}" --region="$REGION" --project="$PROJECT" 2>/dev/null; then

--- a/.github/workflows/_frontend.yml
+++ b/.github/workflows/_frontend.yml
@@ -56,6 +56,11 @@ on:
         required: false
         default: ""
         description: "Custom domain for the app — used as the output URL when sso=true."
+      primary_backend_service:
+        type: string
+        required: false
+        default: ""
+        description: "Cloud Run service name of the primary backend for /api/** routing. Empty = use {app_name}-{environment}."
     outputs:
       url:
         description: "Deployed frontend URL"
@@ -153,7 +158,12 @@ jobs:
         if: inputs.sso != 'true'
         run: |
           SITE_NAME="${{ inputs.site_id != '' && inputs.site_id || format('{0}-{1}', inputs.app_name, inputs.environment) }}"
-          CLOUD_RUN_SERVICE="${{ inputs.app_name }}-${{ inputs.environment }}"
+          # Use explicit primary backend service name if provided (multi-backend), else default
+          if [ -n "${{ inputs.primary_backend_service }}" ]; then
+            CLOUD_RUN_SERVICE="${{ inputs.primary_backend_service }}"
+          else
+            CLOUD_RUN_SERVICE="${{ inputs.app_name }}-${{ inputs.environment }}"
+          fi
           if [ "${{ inputs.has_backend }}" = "true" ]; then
             if [ "${{ inputs.frontend_framework }}" = "static" ]; then
               cat > firebase.json << EOF

--- a/.github/workflows/platform.yml
+++ b/.github/workflows/platform.yml
@@ -52,6 +52,9 @@ jobs:
       backend_dir: ${{ steps.config.outputs.backend_dir }}
       backend_language: ${{ steps.config.outputs.backend_language }}
       backend_port: ${{ steps.config.outputs.backend_port }}
+      backends_json: ${{ steps.config.outputs.backends_json }}
+      backend_names: ${{ steps.config.outputs.backend_names }}
+      primary_backend: ${{ steps.config.outputs.primary_backend }}
       has_database: ${{ steps.config.outputs.has_database }}
       provider: ${{ steps.config.outputs.provider }}
       frontend_changed: ${{ steps.changes.outputs.frontend }}
@@ -95,6 +98,8 @@ jobs:
     outputs:
       backend_url_dev: ${{ steps.tf-out-dev.outputs.backend_url }}
       backend_url_prod: ${{ steps.tf-out-prod.outputs.backend_url }}
+      backend_urls_dev: ${{ steps.tf-out-dev.outputs.backend_urls }}
+      backend_urls_prod: ${{ steps.tf-out-prod.outputs.backend_urls }}
       frontend_url_dev: ${{ steps.tf-out-dev.outputs.frontend_url }}
       frontend_url_prod: ${{ steps.tf-out-prod.outputs.frontend_url }}
       site_id_dev: ${{ steps.tf-out-dev.outputs.site_id }}
@@ -141,6 +146,24 @@ jobs:
           BACKEND_DOMAIN=""
           [ -n "$CUSTOM_DOMAIN" ] && [ "${{ needs.parse-config.outputs.has_backend }}" = "true" ] && BACKEND_DOMAIN="api.${CUSTOM_DOMAIN}"
 
+          # Build backend_services map for Terraform
+          BACKENDS_JSON='${{ needs.parse-config.outputs.backends_json }}'
+          BACKEND_NAMES='${{ needs.parse-config.outputs.backend_names }}'
+
+          # Convert backends JSON array to Terraform map variable
+          # Format: {"api":true,"predictor":true} — Terraform uses for_each on the keys
+          if [ -n "$BACKEND_NAMES" ] && [ "$BACKEND_NAMES" != "backend" ]; then
+            # Multi-backend: pass service names as a set
+            BACKEND_SERVICES_VAR=$(echo "$BACKENDS_JSON" | python3 -c "
+          import json, sys
+          backends = json.load(sys.stdin)
+          result = {b['name']: True for b in backends}
+          print(json.dumps(result))
+          ")
+          else
+            BACKEND_SERVICES_VAR='{}'
+          fi
+
           HAS_SSO="${{ needs.parse-config.outputs.has_sso }}"
           TF_VARS="-var=app_name=${{ needs.parse-config.outputs.app_name }} \
             -var=environment=dev \
@@ -155,6 +178,12 @@ jobs:
             -var=has_sso=${HAS_SSO} \
             -var=iap_allowed_domain=${{ vars.STACKRAMP_IAP_DOMAIN || '' }}"
 
+          # Only pass backend_services when there are multiple backends
+          if [ "$BACKEND_SERVICES_VAR" != '{}' ]; then
+            TF_VARS="$TF_VARS -var=backend_services=${BACKEND_SERVICES_VAR}"
+            TF_VARS="$TF_VARS -var=primary_backend_name=${{ needs.parse-config.outputs.primary_backend }}"
+          fi
+
           terraform apply -auto-approve $TF_VARS
 
       - name: Capture dev outputs
@@ -166,6 +195,8 @@ jobs:
           echo "site_id=$(terraform output -raw site_id 2>/dev/null || echo '')" >> $GITHUB_OUTPUT
           echo "storage_bucket=$(terraform output -raw storage_bucket 2>/dev/null || echo '')" >> $GITHUB_OUTPUT
           echo "database_secret_name=$(terraform output -raw database_secret_name 2>/dev/null || echo '')" >> $GITHUB_OUTPUT
+          # Capture all backend URLs as JSON map for service discovery
+          echo "backend_urls=$(terraform output -json backend_urls 2>/dev/null || echo '{}')" >> $GITHUB_OUTPUT
 
       - name: Terraform init (prod)
         if: github.ref == 'refs/heads/main' && github.event_name == 'push'
@@ -183,6 +214,20 @@ jobs:
           BACKEND_DOMAIN=""
           [ -n "$CUSTOM_DOMAIN" ] && [ "${{ needs.parse-config.outputs.has_backend }}" = "true" ] && BACKEND_DOMAIN="api.${CUSTOM_DOMAIN}"
 
+          BACKENDS_JSON='${{ needs.parse-config.outputs.backends_json }}'
+          BACKEND_NAMES='${{ needs.parse-config.outputs.backend_names }}'
+
+          if [ -n "$BACKEND_NAMES" ] && [ "$BACKEND_NAMES" != "backend" ]; then
+            BACKEND_SERVICES_VAR=$(echo "$BACKENDS_JSON" | python3 -c "
+          import json, sys
+          backends = json.load(sys.stdin)
+          result = {b['name']: True for b in backends}
+          print(json.dumps(result))
+          ")
+          else
+            BACKEND_SERVICES_VAR='{}'
+          fi
+
           HAS_SSO="${{ needs.parse-config.outputs.has_sso }}"
           TF_VARS="-var=app_name=${{ needs.parse-config.outputs.app_name }} \
             -var=environment=prod \
@@ -197,6 +242,11 @@ jobs:
             -var=has_sso=${HAS_SSO} \
             -var=iap_allowed_domain=${{ vars.STACKRAMP_IAP_DOMAIN || '' }}"
 
+          if [ "$BACKEND_SERVICES_VAR" != '{}' ]; then
+            TF_VARS="$TF_VARS -var=backend_services=${BACKEND_SERVICES_VAR}"
+            TF_VARS="$TF_VARS -var=primary_backend_name=${{ needs.parse-config.outputs.primary_backend }}"
+          fi
+
           terraform apply -auto-approve $TF_VARS
 
       - name: Capture prod outputs
@@ -209,17 +259,208 @@ jobs:
           echo "site_id=$(terraform output -raw site_id 2>/dev/null || echo '')" >> $GITHUB_OUTPUT
           echo "storage_bucket=$(terraform output -raw storage_bucket 2>/dev/null || echo '')" >> $GITHUB_OUTPUT
           echo "database_secret_name=$(terraform output -raw database_secret_name 2>/dev/null || echo '')" >> $GITHUB_OUTPUT
+          echo "backend_urls=$(terraform output -json backend_urls 2>/dev/null || echo '{}')" >> $GITHUB_OUTPUT
 
   # ─────────────────────────────────────────────────────────────────────────────
-  # 3. Deploy frontend (if changed)
+  # 3a. Deploy backends (dev) — iterates over all backend services
+  # ─────────────────────────────────────────────────────────────────────────────
+  deploy-backends:
+    name: Backends (dev)
+    needs: [parse-config, provision]
+    if: |
+      needs.parse-config.outputs.has_backend == 'true' &&
+      (needs.parse-config.outputs.backend_changed == 'true' || github.event_name == 'workflow_dispatch' || github.event_name == 'pull_request')
+    runs-on: ubuntu-latest
+    outputs:
+      deployed: ${{ steps.deploy-all.outputs.deployed }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Checkout StackRamp platform
+        uses: actions/checkout@v4
+        with:
+          repository: bobbydeveaux/stackramp
+          ref: main
+          path: .stackramp
+
+      - name: Authenticate to Google Cloud
+        uses: bobbydeveaux/stackramp/providers/gcp/workflows/auth@main
+        with:
+          wif_provider: ${{ vars.STACKRAMP_WIF_PROVIDER }}
+          service_account: ${{ vars.STACKRAMP_SA_EMAIL }}
+
+      - name: Setup gcloud
+        uses: google-github-actions/setup-gcloud@v2
+
+      - name: Configure Docker for Artifact Registry
+        run: gcloud auth configure-docker ${{ vars.STACKRAMP_REGION || 'europe-west1' }}-docker.pkg.dev
+
+      - name: Deploy all backend services
+        id: deploy-all
+        run: |
+          APP_NAME="${{ needs.parse-config.outputs.app_name }}"
+          ENVIRONMENT="${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.number) || 'dev' }}"
+          REGION="${{ vars.STACKRAMP_REGION || 'europe-west1' }}"
+          PROJECT="${{ vars.STACKRAMP_PROJECT }}"
+          FRONTEND_URL="${{ needs.provision.outputs.frontend_url_dev }}"
+          STORAGE_BUCKET="${{ needs.provision.outputs.storage_bucket_dev }}"
+          DATABASE_SECRET="${{ needs.provision.outputs.database_secret_name_dev }}"
+          CLOUDSQL_CONN="${{ vars.STACKRAMP_CLOUDSQL_CONNECTION }}"
+          SSO="${{ needs.parse-config.outputs.has_sso }}"
+          BACKEND_URLS_JSON='${{ needs.provision.outputs.backend_urls_dev }}'
+          BACKENDS_JSON='${{ needs.parse-config.outputs.backends_json }}'
+          BACKEND_NAMES='${{ needs.parse-config.outputs.backend_names }}'
+
+          # Parse backends JSON
+          BACKEND_COUNT=$(echo "$BACKENDS_JSON" | python3 -c "import json,sys; print(len(json.load(sys.stdin)))")
+
+          for i in $(seq 0 $((BACKEND_COUNT - 1))); do
+            # Extract backend config
+            BACKEND=$(echo "$BACKENDS_JSON" | python3 -c "import json,sys; b=json.load(sys.stdin)[$i]; print(json.dumps(b))")
+            NAME=$(echo "$BACKEND" | python3 -c "import json,sys; print(json.load(sys.stdin)['name'])")
+            LANGUAGE=$(echo "$BACKEND" | python3 -c "import json,sys; print(json.load(sys.stdin)['language'])")
+            DIR=$(echo "$BACKEND" | python3 -c "import json,sys; print(json.load(sys.stdin)['dir'])")
+            PORT=$(echo "$BACKEND" | python3 -c "import json,sys; print(json.load(sys.stdin)['port'])")
+            MEMORY=$(echo "$BACKEND" | python3 -c "import json,sys; print(json.load(sys.stdin)['memory'])")
+            CPU=$(echo "$BACKEND" | python3 -c "import json,sys; print(json.load(sys.stdin)['cpu'])")
+            BACKEND_ENV=$(echo "$BACKEND" | python3 -c "import json,sys; print(json.dumps(json.load(sys.stdin).get('env',{})))")
+
+            echo "::group::Deploying backend: $NAME ($LANGUAGE, $DIR:$PORT)"
+
+            # ── Determine Cloud Run service name and image tag ──
+            if [ "$BACKEND_COUNT" -gt 1 ]; then
+              SERVICE_NAME="${APP_NAME}-${NAME}-${ENVIRONMENT}"
+              IMAGE="${REGION}-docker.pkg.dev/${PROJECT}/stackramp-images/${APP_NAME}-${NAME}:${GITHUB_SHA}"
+            else
+              SERVICE_NAME="${APP_NAME}-${ENVIRONMENT}"
+              IMAGE="${REGION}-docker.pkg.dev/${PROJECT}/stackramp-images/${APP_NAME}:${GITHUB_SHA}"
+            fi
+
+            # ── Build Docker image ──
+            if [ -f "${DIR}/Dockerfile" ]; then
+              echo "Using custom Dockerfile from ${DIR}/Dockerfile"
+              docker build -t "$IMAGE" "${DIR}/"
+            else
+              echo "Using platform Dockerfile for ${LANGUAGE}"
+              docker build \
+                -t "$IMAGE" \
+                -f ".stackramp/platform-action/dockerfiles/${LANGUAGE}.Dockerfile" \
+                "${DIR}/"
+            fi
+            docker push "$IMAGE"
+
+            # ── Build env vars ──
+            ENV_VARS="ENVIRONMENT=${ENVIRONMENT},APP_NAME=${APP_NAME},FRONTEND_URL=${FRONTEND_URL}"
+            [ -n "$STORAGE_BUCKET" ] && ENV_VARS="${ENV_VARS},GCS_BUCKET=${STORAGE_BUCKET}"
+
+            # Service discovery: inject other backends' URLs as env vars
+            # e.g. for a backend named "predictor", inject PREDICTOR_URL=https://...
+            if [ "$BACKEND_COUNT" -gt 1 ] && [ "$BACKEND_URLS_JSON" != "{}" ] && [ -n "$BACKEND_URLS_JSON" ]; then
+              DISCOVERY_VARS=$(echo "$BACKEND_URLS_JSON" | python3 -c "
+          import json, sys
+          urls = json.load(sys.stdin)
+          current = '${NAME}'
+          parts = []
+          for svc_name, url in urls.items():
+            if svc_name != current:
+              env_key = svc_name.upper().replace('-', '_') + '_URL'
+              parts.append(f'{env_key}={url}')
+          print(','.join(parts))
+          ")
+              [ -n "$DISCOVERY_VARS" ] && ENV_VARS="${ENV_VARS},${DISCOVERY_VARS}"
+            fi
+
+            # Resolve ${backends.<name>.url} references in user-defined env vars
+            if [ "$BACKEND_ENV" != "{}" ] && [ "$BACKEND_ENV" != "null" ]; then
+              USER_ENV=$(echo "$BACKEND_ENV" | python3 -c "
+          import json, sys, re
+          env = json.load(sys.stdin)
+          urls_raw = '''${BACKEND_URLS_JSON}'''
+          try:
+            urls = json.loads(urls_raw) if urls_raw else {}
+          except:
+            urls = {}
+          parts = []
+          for k, v in env.items():
+            # Replace \${backends.<name>.url} with actual URL
+            def replacer(m):
+              svc = m.group(1)
+              return urls.get(svc, m.group(0))
+            resolved = re.sub(r'\\\$\{backends\.([^.]+)\.url\}', replacer, str(v))
+            parts.append(f'{k}={resolved}')
+          print(','.join(parts))
+          ")
+              [ -n "$USER_ENV" ] && ENV_VARS="${ENV_VARS},${USER_ENV}"
+            fi
+
+            # Load .env file if present
+            ENV_FILE="${DIR}/.env.${ENVIRONMENT}"
+            if [ -f "$ENV_FILE" ]; then
+              echo "Loading env vars from $ENV_FILE"
+              while IFS= read -r line || [ -n "$line" ]; do
+                [[ -z "$line" || "$line" == \#* ]] && continue
+                ENV_VARS="${ENV_VARS},${line}"
+              done < "$ENV_FILE"
+            fi
+
+            # ── Secret refs ──
+            SECRET_REFS=""
+            PLATFORM_SECRETS=$(gcloud secrets list \
+              --filter="labels.platform-inject=true" \
+              --format="value(name)" \
+              --project="${PROJECT}")
+            for SECRET_RESOURCE in $PLATFORM_SECRETS; do
+              SECRET_NAME=$(basename "$SECRET_RESOURCE")
+              SECRET_REFS="${SECRET_REFS:+$SECRET_REFS,}${SECRET_NAME}=${SECRET_NAME}:latest"
+            done
+            [ -n "$DATABASE_SECRET" ] && SECRET_REFS="${SECRET_REFS:+$SECRET_REFS,}DATABASE_URL=${DATABASE_SECRET}:latest"
+
+            # ── Deploy to Cloud Run ──
+            DEPLOY_FLAGS=(
+              --image="$IMAGE"
+              --region="${REGION}"
+              --platform=managed
+              --port="${PORT}"
+              --set-env-vars="${ENV_VARS}"
+              --memory="${MEMORY}"
+              --cpu="${CPU}"
+              --min-instances=1
+              --max-instances=10
+              --timeout=300
+              --cpu-throttling
+              --project="${PROJECT}"
+            )
+            if [ "$SSO" = "true" ]; then
+              DEPLOY_FLAGS+=(--allow-unauthenticated --ingress=internal-and-cloud-load-balancing)
+            else
+              DEPLOY_FLAGS+=(--allow-unauthenticated --ingress=all)
+            fi
+            [ -n "$SECRET_REFS" ] && DEPLOY_FLAGS+=(--set-secrets="$SECRET_REFS")
+            [ -n "$CLOUDSQL_CONN" ] && DEPLOY_FLAGS+=(--add-cloudsql-instances="${CLOUDSQL_CONN}")
+
+            gcloud run deploy "$SERVICE_NAME" "${DEPLOY_FLAGS[@]}"
+
+            URL=$(gcloud run services describe "$SERVICE_NAME" \
+              --region="$REGION" \
+              --project="$PROJECT" \
+              --format="value(status.url)")
+            echo "Deployed $NAME: $URL"
+
+            echo "::endgroup::"
+          done
+
+          echo "deployed=true" >> $GITHUB_OUTPUT
+
+  # ─────────────────────────────────────────────────────────────────────────────
+  # 3b. Deploy frontend (if changed)
   # ─────────────────────────────────────────────────────────────────────────────
   deploy-frontend:
     name: Frontend
-    needs: [parse-config, provision, deploy-backend]
+    needs: [parse-config, provision, deploy-backends]
     if: |
       always() &&
       needs.parse-config.result == 'success' && needs.provision.result == 'success' &&
-      (needs.deploy-backend.result == 'success' || needs.deploy-backend.result == 'skipped') &&
+      (needs.deploy-backends.result == 'success' || needs.deploy-backends.result == 'skipped') &&
       needs.parse-config.outputs.has_frontend == 'true' &&
       (needs.parse-config.outputs.frontend_changed == 'true' || github.event_name == 'workflow_dispatch' || github.event_name == 'pull_request')
     uses: bobbydeveaux/stackramp/.github/workflows/_frontend.yml@main
@@ -239,39 +480,14 @@ jobs:
       site_id: ${{ needs.provision.outputs.site_id_dev }}
       sso: ${{ needs.parse-config.outputs.has_sso }}
       custom_domain: ${{ needs.parse-config.outputs.custom_domain }}
-
-  # ─────────────────────────────────────────────────────────────────────────────
-  # 3. Deploy backend (if changed)
-  # ─────────────────────────────────────────────────────────────────────────────
-  deploy-backend:
-    name: Backend
-    needs: [parse-config, provision]
-    if: |
-      needs.parse-config.outputs.has_backend == 'true' &&
-      (needs.parse-config.outputs.backend_changed == 'true' || github.event_name == 'workflow_dispatch' || github.event_name == 'pull_request')
-    uses: bobbydeveaux/stackramp/.github/workflows/_backend.yml@main
-    secrets: inherit
-    with:
-      app_name: ${{ needs.parse-config.outputs.app_name }}
-      backend_dir: ${{ needs.parse-config.outputs.backend_dir }}
-      backend_language: ${{ needs.parse-config.outputs.backend_language }}
-      backend_port: ${{ fromJson(needs.parse-config.outputs.backend_port) }}
-      environment: ${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.number) || 'dev' }}
-      platform_project: ${{ vars.STACKRAMP_PROJECT }}
-      region: ${{ vars.STACKRAMP_REGION || 'europe-west1' }}
-      wif_provider: ${{ vars.STACKRAMP_WIF_PROVIDER }}
-      service_account: ${{ vars.STACKRAMP_SA_EMAIL }}
-      frontend_url: ${{ needs.provision.outputs.frontend_url_dev }}
-      storage_bucket: ${{ needs.provision.outputs.storage_bucket_dev }}
-      cloudsql_connection_name: ${{ vars.STACKRAMP_CLOUDSQL_CONNECTION || '' }}
-      database_secret_name: ${{ needs.provision.outputs.database_secret_name_dev }}
-      sso: ${{ needs.parse-config.outputs.has_sso }}
+      # For multi-backend: tell the frontend which Cloud Run service handles /api/**
+      primary_backend_service: ${{ needs.parse-config.outputs.backend_names != 'backend' && needs.parse-config.outputs.primary_backend != '' && format('{0}-{1}-{2}', needs.parse-config.outputs.app_name, needs.parse-config.outputs.primary_backend, github.event_name == 'pull_request' && format('pr-{0}', github.event.number) || 'dev') || '' }}
 
   # ─────────────────────────────────────────────────────────────────────────────
   # 4. Deploy to PROD (main branch only, after dev succeeds)
   # ─────────────────────────────────────────────────────────────────────────────
   deploy-frontend-prod:
-    name: Frontend → prod
+    name: Frontend (prod)
     needs: [parse-config, provision, deploy-frontend]
     if: |
       always() &&
@@ -296,30 +512,174 @@ jobs:
       site_id: ${{ needs.provision.outputs.site_id_prod }}
       sso: ${{ needs.parse-config.outputs.has_sso }}
       custom_domain: ${{ needs.parse-config.outputs.custom_domain }}
+      primary_backend_service: ${{ needs.parse-config.outputs.backend_names != 'backend' && needs.parse-config.outputs.primary_backend != '' && format('{0}-{1}-prod', needs.parse-config.outputs.app_name, needs.parse-config.outputs.primary_backend) || '' }}
 
-  deploy-backend-prod:
-    name: Backend → prod
-    needs: [parse-config, provision, deploy-backend]
+  deploy-backends-prod:
+    name: Backends (prod)
+    needs: [parse-config, provision, deploy-backends]
     if: |
       always() &&
       github.ref == 'refs/heads/main' &&
       (github.event_name == 'push' || github.event_name == 'workflow_dispatch') &&
       needs.parse-config.outputs.has_backend == 'true' &&
-      (needs.deploy-backend.result == 'success' || needs.deploy-backend.result == 'skipped')
-    uses: bobbydeveaux/stackramp/.github/workflows/_backend.yml@main
-    secrets: inherit
-    with:
-      app_name: ${{ needs.parse-config.outputs.app_name }}
-      backend_dir: ${{ needs.parse-config.outputs.backend_dir }}
-      backend_language: ${{ needs.parse-config.outputs.backend_language }}
-      backend_port: ${{ fromJson(needs.parse-config.outputs.backend_port) }}
-      environment: prod
-      platform_project: ${{ vars.STACKRAMP_PROJECT }}
-      region: ${{ vars.STACKRAMP_REGION || 'europe-west1' }}
-      wif_provider: ${{ vars.STACKRAMP_WIF_PROVIDER }}
-      service_account: ${{ vars.STACKRAMP_SA_EMAIL }}
-      frontend_url: ${{ needs.provision.outputs.frontend_url_prod }}
-      storage_bucket: ${{ needs.provision.outputs.storage_bucket_prod }}
-      cloudsql_connection_name: ${{ vars.STACKRAMP_CLOUDSQL_CONNECTION || '' }}
-      database_secret_name: ${{ needs.provision.outputs.database_secret_name_prod }}
-      sso: ${{ needs.parse-config.outputs.has_sso }}
+      (needs.deploy-backends.result == 'success' || needs.deploy-backends.result == 'skipped')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Checkout StackRamp platform
+        uses: actions/checkout@v4
+        with:
+          repository: bobbydeveaux/stackramp
+          ref: main
+          path: .stackramp
+
+      - name: Authenticate to Google Cloud
+        uses: bobbydeveaux/stackramp/providers/gcp/workflows/auth@main
+        with:
+          wif_provider: ${{ vars.STACKRAMP_WIF_PROVIDER }}
+          service_account: ${{ vars.STACKRAMP_SA_EMAIL }}
+
+      - name: Setup gcloud
+        uses: google-github-actions/setup-gcloud@v2
+
+      - name: Configure Docker for Artifact Registry
+        run: gcloud auth configure-docker ${{ vars.STACKRAMP_REGION || 'europe-west1' }}-docker.pkg.dev
+
+      - name: Deploy all backend services (prod)
+        run: |
+          APP_NAME="${{ needs.parse-config.outputs.app_name }}"
+          ENVIRONMENT="prod"
+          REGION="${{ vars.STACKRAMP_REGION || 'europe-west1' }}"
+          PROJECT="${{ vars.STACKRAMP_PROJECT }}"
+          FRONTEND_URL="${{ needs.provision.outputs.frontend_url_prod }}"
+          STORAGE_BUCKET="${{ needs.provision.outputs.storage_bucket_prod }}"
+          DATABASE_SECRET="${{ needs.provision.outputs.database_secret_name_prod }}"
+          CLOUDSQL_CONN="${{ vars.STACKRAMP_CLOUDSQL_CONNECTION }}"
+          SSO="${{ needs.parse-config.outputs.has_sso }}"
+          BACKEND_URLS_JSON='${{ needs.provision.outputs.backend_urls_prod }}'
+          BACKENDS_JSON='${{ needs.parse-config.outputs.backends_json }}'
+          BACKEND_NAMES='${{ needs.parse-config.outputs.backend_names }}'
+
+          BACKEND_COUNT=$(echo "$BACKENDS_JSON" | python3 -c "import json,sys; print(len(json.load(sys.stdin)))")
+
+          for i in $(seq 0 $((BACKEND_COUNT - 1))); do
+            BACKEND=$(echo "$BACKENDS_JSON" | python3 -c "import json,sys; b=json.load(sys.stdin)[$i]; print(json.dumps(b))")
+            NAME=$(echo "$BACKEND" | python3 -c "import json,sys; print(json.load(sys.stdin)['name'])")
+            LANGUAGE=$(echo "$BACKEND" | python3 -c "import json,sys; print(json.load(sys.stdin)['language'])")
+            DIR=$(echo "$BACKEND" | python3 -c "import json,sys; print(json.load(sys.stdin)['dir'])")
+            PORT=$(echo "$BACKEND" | python3 -c "import json,sys; print(json.load(sys.stdin)['port'])")
+            MEMORY=$(echo "$BACKEND" | python3 -c "import json,sys; print(json.load(sys.stdin)['memory'])")
+            CPU=$(echo "$BACKEND" | python3 -c "import json,sys; print(json.load(sys.stdin)['cpu'])")
+            BACKEND_ENV=$(echo "$BACKEND" | python3 -c "import json,sys; print(json.dumps(json.load(sys.stdin).get('env',{})))")
+
+            echo "::group::Deploying backend: $NAME ($LANGUAGE, $DIR:$PORT)"
+
+            if [ "$BACKEND_COUNT" -gt 1 ]; then
+              SERVICE_NAME="${APP_NAME}-${NAME}-${ENVIRONMENT}"
+              IMAGE="${REGION}-docker.pkg.dev/${PROJECT}/stackramp-images/${APP_NAME}-${NAME}:${GITHUB_SHA}"
+            else
+              SERVICE_NAME="${APP_NAME}-${ENVIRONMENT}"
+              IMAGE="${REGION}-docker.pkg.dev/${PROJECT}/stackramp-images/${APP_NAME}:${GITHUB_SHA}"
+            fi
+
+            if [ -f "${DIR}/Dockerfile" ]; then
+              docker build -t "$IMAGE" "${DIR}/"
+            else
+              docker build \
+                -t "$IMAGE" \
+                -f ".stackramp/platform-action/dockerfiles/${LANGUAGE}.Dockerfile" \
+                "${DIR}/"
+            fi
+            docker push "$IMAGE"
+
+            ENV_VARS="ENVIRONMENT=${ENVIRONMENT},APP_NAME=${APP_NAME},FRONTEND_URL=${FRONTEND_URL}"
+            [ -n "$STORAGE_BUCKET" ] && ENV_VARS="${ENV_VARS},GCS_BUCKET=${STORAGE_BUCKET}"
+
+            if [ "$BACKEND_COUNT" -gt 1 ] && [ "$BACKEND_URLS_JSON" != "{}" ] && [ -n "$BACKEND_URLS_JSON" ]; then
+              DISCOVERY_VARS=$(echo "$BACKEND_URLS_JSON" | python3 -c "
+          import json, sys
+          urls = json.load(sys.stdin)
+          current = '${NAME}'
+          parts = []
+          for svc_name, url in urls.items():
+            if svc_name != current:
+              env_key = svc_name.upper().replace('-', '_') + '_URL'
+              parts.append(f'{env_key}={url}')
+          print(','.join(parts))
+          ")
+              [ -n "$DISCOVERY_VARS" ] && ENV_VARS="${ENV_VARS},${DISCOVERY_VARS}"
+            fi
+
+            if [ "$BACKEND_ENV" != "{}" ] && [ "$BACKEND_ENV" != "null" ]; then
+              USER_ENV=$(echo "$BACKEND_ENV" | python3 -c "
+          import json, sys, re
+          env = json.load(sys.stdin)
+          urls_raw = '''${BACKEND_URLS_JSON}'''
+          try:
+            urls = json.loads(urls_raw) if urls_raw else {}
+          except:
+            urls = {}
+          parts = []
+          for k, v in env.items():
+            def replacer(m):
+              svc = m.group(1)
+              return urls.get(svc, m.group(0))
+            resolved = re.sub(r'\\\$\{backends\.([^.]+)\.url\}', replacer, str(v))
+            parts.append(f'{k}={resolved}')
+          print(','.join(parts))
+          ")
+              [ -n "$USER_ENV" ] && ENV_VARS="${ENV_VARS},${USER_ENV}"
+            fi
+
+            ENV_FILE="${DIR}/.env.${ENVIRONMENT}"
+            if [ -f "$ENV_FILE" ]; then
+              while IFS= read -r line || [ -n "$line" ]; do
+                [[ -z "$line" || "$line" == \#* ]] && continue
+                ENV_VARS="${ENV_VARS},${line}"
+              done < "$ENV_FILE"
+            fi
+
+            SECRET_REFS=""
+            PLATFORM_SECRETS=$(gcloud secrets list \
+              --filter="labels.platform-inject=true" \
+              --format="value(name)" \
+              --project="${PROJECT}")
+            for SECRET_RESOURCE in $PLATFORM_SECRETS; do
+              SECRET_NAME=$(basename "$SECRET_RESOURCE")
+              SECRET_REFS="${SECRET_REFS:+$SECRET_REFS,}${SECRET_NAME}=${SECRET_NAME}:latest"
+            done
+            [ -n "$DATABASE_SECRET" ] && SECRET_REFS="${SECRET_REFS:+$SECRET_REFS,}DATABASE_URL=${DATABASE_SECRET}:latest"
+
+            DEPLOY_FLAGS=(
+              --image="$IMAGE"
+              --region="${REGION}"
+              --platform=managed
+              --port="${PORT}"
+              --set-env-vars="${ENV_VARS}"
+              --memory="${MEMORY}"
+              --cpu="${CPU}"
+              --min-instances=1
+              --max-instances=10
+              --timeout=300
+              --cpu-throttling
+              --project="${PROJECT}"
+            )
+            if [ "$SSO" = "true" ]; then
+              DEPLOY_FLAGS+=(--allow-unauthenticated --ingress=internal-and-cloud-load-balancing)
+            else
+              DEPLOY_FLAGS+=(--allow-unauthenticated --ingress=all)
+            fi
+            [ -n "$SECRET_REFS" ] && DEPLOY_FLAGS+=(--set-secrets="$SECRET_REFS")
+            [ -n "$CLOUDSQL_CONN" ] && DEPLOY_FLAGS+=(--add-cloudsql-instances="${CLOUDSQL_CONN}")
+
+            gcloud run deploy "$SERVICE_NAME" "${DEPLOY_FLAGS[@]}"
+
+            URL=$(gcloud run services describe "$SERVICE_NAME" \
+              --region="$REGION" \
+              --project="$PROJECT" \
+              --format="value(status.url)")
+            echo "Deployed $NAME (prod): $URL"
+
+            echo "::endgroup::"
+          done

--- a/docs/stackramp-yaml-reference.md
+++ b/docs/stackramp-yaml-reference.md
@@ -179,6 +179,79 @@ CPU allocation for the backend service. Examples: `1`, `2`, `4`.
 
 ---
 
+### `backends` (optional — multi-service)
+
+Use `backends` (plural) instead of `backend` (singular) when your application needs multiple independent backend services. Each key is a service name, and each service gets its own Cloud Run deployment with independent language, directory, port, CPU, and memory configuration.
+
+**`backend` and `backends` are mutually exclusive** — use one or the other. Existing apps using `backend` continue to work unchanged.
+
+#### Full Example
+
+```yaml
+name: trade-simulator
+
+frontend:
+  framework: static
+  dir: frontend
+
+backends:
+  api:
+    language: rust
+    dir: backend
+    port: 8080
+    primary: true
+    env:
+      PREDICTOR_URL: ${backends.predictor.url}
+  predictor:
+    language: python
+    dir: predictor
+    port: 8085
+    memory: 1Gi
+    cpu: "2"
+```
+
+#### Per-service fields
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `language` | `string` | `none` | `python`, `go`, `node`, `rust`, `none` |
+| `dir` | `string` | service name | Directory containing service code |
+| `port` | `integer` | `8080` | Port the service listens on |
+| `memory` | `string` | `512Mi` | Cloud Run memory allocation |
+| `cpu` | `string` | `1` | Cloud Run CPU allocation |
+| `primary` | `boolean` | `false` | Marks this service as the primary backend for `/api/**` routing |
+| `env` | `object` | `{}` | Additional environment variables (key-value pairs) |
+
+#### Service discovery
+
+Each backend automatically receives the URLs of all other backends as environment variables. The variable name is derived from the service name:
+
+- A service named `predictor` is available to other services as `PREDICTOR_URL`
+- A service named `auth-service` is available as `AUTH_SERVICE_URL`
+
+You can also explicitly reference other services in the `env` block using the `${backends.<name>.url}` syntax:
+
+```yaml
+env:
+  PREDICTOR_URL: ${backends.predictor.url}
+```
+
+Both automatic injection and explicit references resolve to the Cloud Run service URL (e.g. `https://myapp-predictor-dev-abc123.a.run.app`).
+
+#### Primary backend
+
+The primary backend handles `/api/**` routing from the frontend (via Firebase Hosting rewrites or the SSO load balancer URL map). You can mark a backend as primary with `primary: true`. If no backend is explicitly marked, the first one listed is used.
+
+#### Cloud Run naming
+
+Each backend gets a separate Cloud Run service named `{app_name}-{service_name}-{environment}`:
+- `trade-simulator-api-dev`
+- `trade-simulator-predictor-dev`
+- `trade-simulator-api-prod`
+- `trade-simulator-predictor-prod`
+
+---
+
 ### `database`
 
 | | |

--- a/platform-action/action.yml
+++ b/platform-action/action.yml
@@ -24,14 +24,23 @@ outputs:
     description: "Whether the app has a backend"
     value: ${{ steps.parse.outputs.has_backend }}
   backend_language:
-    description: "Backend language (python, go, node, none)"
+    description: "Backend language (python, go, node, none) — primary backend for backwards compat"
     value: ${{ steps.parse.outputs.backend_language }}
   backend_dir:
-    description: "Backend directory"
+    description: "Backend directory — primary backend for backwards compat"
     value: ${{ steps.parse.outputs.backend_dir }}
   backend_port:
-    description: "Backend port"
+    description: "Backend port — primary backend for backwards compat"
     value: ${{ steps.parse.outputs.backend_port }}
+  backends_json:
+    description: "JSON array of backend service configs [{name, language, dir, port, memory, cpu, primary, env}]"
+    value: ${{ steps.parse.outputs.backends_json }}
+  backend_names:
+    description: "Comma-separated list of backend service names"
+    value: ${{ steps.parse.outputs.backend_names }}
+  primary_backend:
+    description: "Name of the primary backend service (handles /api/** routing)"
+    value: ${{ steps.parse.outputs.primary_backend }}
   has_database:
     description: "Whether the app uses a database"
     value: ${{ steps.parse.outputs.has_database }}
@@ -80,9 +89,6 @@ runs:
 
         FRONTEND_FRAMEWORK=$(yq '.frontend.framework // "none"' "$CONFIG")
         FRONTEND_DIR=$(yq '.frontend.dir // "frontend"' "$CONFIG")
-        BACKEND_LANG=$(yq '.backend.language // "none"' "$CONFIG")
-        BACKEND_DIR=$(yq '.backend.dir // "backend"' "$CONFIG")
-        BACKEND_PORT=$(yq '.backend.port // 8080' "$CONFIG")
         DATABASE=$(yq '.database // false' "$CONFIG")
         PROVIDER="${STACKRAMP_PROVIDER:-$(yq '.provider.cloud // "gcp"' "$CONFIG")}"
 
@@ -99,12 +105,81 @@ runs:
         HAS_FRONTEND="false"
         [ "$FRONTEND_FRAMEWORK" != "none" ] && [ "$FRONTEND_FRAMEWORK" != "null" ] && HAS_FRONTEND="true"
 
+        # ── Parse backends (plural) or backend (singular, backwards-compatible) ──
+        HAS_BACKENDS=$(yq '.backends // "" | type' "$CONFIG")
+        HAS_SINGULAR=$(yq '.backend // "" | type' "$CONFIG")
+
+        BACKENDS_JSON="[]"
         HAS_BACKEND="false"
-        [ "$BACKEND_LANG" != "none" ] && [ "$BACKEND_LANG" != "null" ] && HAS_BACKEND="true"
+
+        if [ "$HAS_BACKENDS" = "!!map" ]; then
+          # New plural format: backends: { api: {...}, predictor: {...} }
+          BACKENDS_JSON=$(yq -o=json '[.backends | to_entries[] | {
+            "name": .key,
+            "language": (.value.language // "none"),
+            "dir": (.value.dir // .key),
+            "port": (.value.port // 8080),
+            "memory": (.value.memory // "512Mi"),
+            "cpu": (.value.cpu // "1"),
+            "primary": (.value.primary // false),
+            "env": (.value.env // {})
+          }]' "$CONFIG")
+
+          BACKEND_COUNT=$(echo "$BACKENDS_JSON" | yq '. | length')
+          if [ "$BACKEND_COUNT" -gt 0 ]; then
+            HAS_BACKEND="true"
+
+            # Check if any backend has language != "none"
+            ALL_NONE=$(echo "$BACKENDS_JSON" | yq '[.[].language] | all_c(. == "none")')
+            [ "$ALL_NONE" = "true" ] && HAS_BACKEND="false"
+          fi
+
+          # Determine primary: explicitly marked, or first entry
+          PRIMARY=$(echo "$BACKENDS_JSON" | yq '[.[] | select(.primary == true)] | .[0].name // ""')
+          if [ -z "$PRIMARY" ] || [ "$PRIMARY" = "null" ]; then
+            PRIMARY=$(echo "$BACKENDS_JSON" | yq '.[0].name')
+          fi
+
+        elif [ "$HAS_SINGULAR" = "!!map" ]; then
+          # Legacy singular format: backend: { language: python, ... }
+          BACKEND_LANG=$(yq '.backend.language // "none"' "$CONFIG")
+          BACKEND_DIR=$(yq '.backend.dir // "backend"' "$CONFIG")
+          BACKEND_PORT=$(yq '.backend.port // 8080' "$CONFIG")
+          BACKEND_MEMORY=$(yq '.backend.memory // "512Mi"' "$CONFIG")
+          BACKEND_CPU=$(yq '.backend.cpu // "1"' "$CONFIG")
+
+          if [ "$BACKEND_LANG" != "none" ] && [ "$BACKEND_LANG" != "null" ]; then
+            HAS_BACKEND="true"
+            BACKENDS_JSON=$(cat <<EOJSON
+        [{"name":"backend","language":"${BACKEND_LANG}","dir":"${BACKEND_DIR}","port":${BACKEND_PORT},"memory":"${BACKEND_MEMORY}","cpu":"${BACKEND_CPU}","primary":true,"env":{}}]
+        EOJSON
+            )
+          fi
+          PRIMARY="backend"
+        else
+          PRIMARY=""
+        fi
 
         if [ "$HAS_FRONTEND" = "false" ] && [ "$HAS_BACKEND" = "false" ]; then
-          echo "::error::stackramp.yaml must define at least one of frontend or backend."
+          echo "::error::stackramp.yaml must define at least one of frontend, backend, or backends."
           exit 1
+        fi
+
+        # Extract primary backend fields for backwards compatibility
+        if [ "$HAS_BACKEND" = "true" ]; then
+          BACKEND_LANG=$(echo "$BACKENDS_JSON" | yq "[.[] | select(.name == \"${PRIMARY}\")] | .[0].language")
+          BACKEND_DIR=$(echo "$BACKENDS_JSON" | yq "[.[] | select(.name == \"${PRIMARY}\")] | .[0].dir")
+          BACKEND_PORT=$(echo "$BACKENDS_JSON" | yq "[.[] | select(.name == \"${PRIMARY}\")] | .[0].port")
+        else
+          BACKEND_LANG="none"
+          BACKEND_DIR="backend"
+          BACKEND_PORT="8080"
+        fi
+
+        # Build comma-separated list of backend names
+        BACKEND_NAMES=""
+        if [ "$HAS_BACKEND" = "true" ]; then
+          BACKEND_NAMES=$(echo "$BACKENDS_JSON" | yq '[.[].name] | join(",")')
         fi
 
         HAS_DATABASE="false"
@@ -132,6 +207,9 @@ runs:
         echo "backend_language=$BACKEND_LANG" >> $GITHUB_OUTPUT
         echo "backend_dir=$BACKEND_DIR" >> $GITHUB_OUTPUT
         echo "backend_port=$BACKEND_PORT" >> $GITHUB_OUTPUT
+        echo "backends_json=$BACKENDS_JSON" >> $GITHUB_OUTPUT
+        echo "backend_names=$BACKEND_NAMES" >> $GITHUB_OUTPUT
+        echo "primary_backend=$PRIMARY" >> $GITHUB_OUTPUT
         echo "has_database=$HAS_DATABASE" >> $GITHUB_OUTPUT
         echo "provider=$PROVIDER" >> $GITHUB_OUTPUT
         echo "has_storage=$HAS_STORAGE" >> $GITHUB_OUTPUT
@@ -141,7 +219,9 @@ runs:
 
         echo "App: $APP_NAME"
         echo "Frontend: $FRONTEND_FRAMEWORK ($FRONTEND_DIR)"
-        echo "Backend: $BACKEND_LANG ($BACKEND_DIR:$BACKEND_PORT)"
+        echo "Backend (primary): $BACKEND_LANG ($BACKEND_DIR:$BACKEND_PORT)"
+        echo "Backends: $BACKEND_NAMES"
+        echo "Primary backend: $PRIMARY"
         echo "Database: $DATABASE"
         echo "Storage: $STORAGE"
         echo "SSO: $HAS_SSO"

--- a/platform-action/dockerfiles/rust.Dockerfile
+++ b/platform-action/dockerfiles/rust.Dockerfile
@@ -1,0 +1,29 @@
+# StackRamp default Rust Dockerfile
+# Multi-stage build for production-ready Rust apps
+
+FROM rust:1.87-slim AS builder
+
+WORKDIR /app
+
+# Cache dependency builds
+COPY Cargo.toml Cargo.lock* ./
+RUN mkdir src && echo "fn main() {}" > src/main.rs && cargo build --release && rm -rf src
+
+COPY . .
+RUN touch src/main.rs && cargo build --release
+
+FROM debian:bookworm-slim
+
+RUN apt-get update && apt-get install -y ca-certificates && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+COPY --from=builder /app/target/release/* /app/ 2>/dev/null || true
+
+# Find the binary (first executable in /app that isn't a .d file)
+RUN BINARY=$(find /app -maxdepth 1 -type f -executable ! -name '*.d' | head -1) && \
+    ln -sf "$BINARY" /app/server
+
+ENV PORT=8080
+EXPOSE ${PORT}
+
+CMD ["/app/server"]

--- a/platform-action/schema.json
+++ b/platform-action/schema.json
@@ -30,10 +30,11 @@
     },
     "backend": {
       "type": "object",
+      "description": "Single backend configuration (mutually exclusive with 'backends')",
       "properties": {
         "language": {
           "type": "string",
-          "enum": ["python", "go", "node", "none"],
+          "enum": ["python", "go", "node", "rust", "none"],
           "default": "none"
         },
         "dir": {
@@ -51,6 +52,48 @@
         "cpu": {
           "type": "string",
           "default": "1"
+        }
+      }
+    },
+    "backends": {
+      "type": "object",
+      "description": "Multiple named backend services. Each key is a service name.",
+      "additionalProperties": {
+        "type": "object",
+        "properties": {
+          "language": {
+            "type": "string",
+            "enum": ["python", "go", "node", "rust", "none"],
+            "default": "none"
+          },
+          "dir": {
+            "type": "string",
+            "description": "Directory containing the service code (default: same as service name)"
+          },
+          "port": {
+            "type": "integer",
+            "default": 8080
+          },
+          "memory": {
+            "type": "string",
+            "default": "512Mi"
+          },
+          "cpu": {
+            "type": "string",
+            "default": "1"
+          },
+          "primary": {
+            "type": "boolean",
+            "default": false,
+            "description": "Mark this backend as the primary service for /api/** proxy routing from the frontend"
+          },
+          "env": {
+            "type": "object",
+            "description": "Additional environment variables. Supports ${backends.<name>.url} for service discovery.",
+            "additionalProperties": {
+              "type": "string"
+            }
+          }
         }
       }
     },

--- a/providers/gcp/terraform/platform/main.tf
+++ b/providers/gcp/terraform/platform/main.tf
@@ -17,6 +17,12 @@ moved {
   to   = google_cloud_run_v2_service_iam_member.public[0]
 }
 
+# State migration: google_cloud_run_v2_service.app now uses count for multi-backend support
+moved {
+  from = google_cloud_run_v2_service.app
+  to   = google_cloud_run_v2_service.app[0]
+}
+
 # StackRamp Per-App Infrastructure
 # Run idempotently on every deploy to ensure app infra exists.
 # Creates Firebase Hosting site + Cloud Run service for the app.
@@ -86,6 +92,13 @@ locals {
 
   # IAP member — domain:example.com or allAuthenticatedUsers
   iap_member = (var.iap_allowed_domain == "" || var.iap_allowed_domain == "*") ? "allAuthenticatedUsers" : "domain:${var.iap_allowed_domain}"
+
+  # Multi-backend: detect which mode we're in
+  is_multi_backend = length(var.backend_services) > 0
+  # Primary backend service name for SSO URL map routing
+  primary_backend_key = local.is_multi_backend ? (var.primary_backend_name != "" ? var.primary_backend_name : sort(keys(var.backend_services))[0]) : ""
+  # Primary backend Cloud Run service name for NEG/LB
+  primary_backend_cr_name = local.is_multi_backend ? google_cloud_run_v2_service.backends[local.primary_backend_key].name : (length(google_cloud_run_v2_service.app) > 0 ? google_cloud_run_v2_service.app[0].name : "")
 }
 
 # Apex domain: A records pointing at Firebase's stable load-balancer IPs
@@ -111,10 +124,12 @@ resource "google_dns_record_set" "frontend_cname" {
   rrdatas      = ["${google_firebase_hosting_site.app[0].site_id}.web.app."]
 }
 
-# ── Cloud Run Service ─────────────────────────────────────────────────────────
-# Creates the service shell — actual deployment is done by the workflow
+# ── Cloud Run Service (single backend — backwards compatible) ─────────────────
+# Creates the service shell — actual deployment is done by the workflow.
+# Used when backend_services is empty (single backend or legacy config).
 
 resource "google_cloud_run_v2_service" "app" {
+  count               = length(var.backend_services) == 0 ? 1 : 0
   name                = "${var.app_name}-${var.environment}"
   location            = var.region
   project             = var.platform_project
@@ -143,12 +158,60 @@ resource "google_cloud_run_v2_service" "app" {
   }
 }
 
-# Allow unauthenticated access (non-SSO apps only)
+# Allow unauthenticated access — single backend (non-SSO apps only)
 resource "google_cloud_run_v2_service_iam_member" "public" {
-  count    = var.has_sso ? 0 : 1
+  count    = !var.has_sso && length(var.backend_services) == 0 ? 1 : 0
   project  = var.platform_project
   location = var.region
-  name     = google_cloud_run_v2_service.app.name
+  name     = google_cloud_run_v2_service.app[0].name
+  role     = "roles/run.invoker"
+  member   = "allUsers"
+}
+
+# ── Cloud Run Services (multiple backends) ───────────────────────────────────
+# Creates a Cloud Run service shell per named backend. Each gets its own
+# independent service for scaling, language, and resource configuration.
+
+resource "google_cloud_run_v2_service" "backends" {
+  for_each            = var.backend_services
+  name                = "${var.app_name}-${each.key}-${var.environment}"
+  location            = var.region
+  project             = var.platform_project
+  deletion_protection = false
+
+  template {
+    containers {
+      image = "us-docker.pkg.dev/cloudrun/container/hello"
+
+      env {
+        name  = "ENVIRONMENT"
+        value = var.environment
+      }
+      env {
+        name  = "APP_NAME"
+        value = var.app_name
+      }
+      env {
+        name  = "SERVICE_NAME"
+        value = each.key
+      }
+    }
+  }
+
+  lifecycle {
+    ignore_changes = [
+      template[0].containers[0].image,
+      template[0].containers[0].env,
+    ]
+  }
+}
+
+# Allow unauthenticated access — multi-backend (non-SSO apps only)
+resource "google_cloud_run_v2_service_iam_member" "backends_public" {
+  for_each = !var.has_sso ? var.backend_services : {}
+  project  = var.platform_project
+  location = var.region
+  name     = google_cloud_run_v2_service.backends[each.key].name
   role     = "roles/run.invoker"
   member   = "allUsers"
 }
@@ -199,11 +262,22 @@ resource "google_cloud_run_v2_service_iam_member" "iap_frontend_invoker" {
 }
 
 # IAP SA invoker on backend — IAP requires run.invoker even when Cloud Run allows allUsers
+# Single backend mode
 resource "google_cloud_run_v2_service_iam_member" "iap_backend_invoker" {
-  count    = var.has_sso ? 1 : 0
+  count    = var.has_sso && length(var.backend_services) == 0 ? 1 : 0
   project  = var.platform_project
   location = var.region
-  name     = google_cloud_run_v2_service.app.name
+  name     = google_cloud_run_v2_service.app[0].name
+  role     = "roles/run.invoker"
+  member   = "serviceAccount:service-${data.google_project.project.number}@gcp-sa-iap.iam.gserviceaccount.com"
+}
+
+# Multi-backend mode: IAP SA invoker for each backend
+resource "google_cloud_run_v2_service_iam_member" "iap_backends_invoker" {
+  for_each = var.has_sso ? var.backend_services : {}
+  project  = var.platform_project
+  location = var.region
+  name     = google_cloud_run_v2_service.backends[each.key].name
   role     = "roles/run.invoker"
   member   = "serviceAccount:service-${data.google_project.project.number}@gcp-sa-iap.iam.gserviceaccount.com"
 }
@@ -269,7 +343,7 @@ resource "google_compute_region_network_endpoint_group" "backend_neg" {
   project               = var.platform_project
 
   cloud_run {
-    service = google_cloud_run_v2_service.app.name
+    service = local.primary_backend_cr_name
   }
 }
 

--- a/providers/gcp/terraform/platform/outputs.tf
+++ b/providers/gcp/terraform/platform/outputs.tf
@@ -13,8 +13,19 @@ output "frontend_url" {
 }
 
 output "backend_url" {
-  description = "Backend Cloud Run URI"
-  value       = google_cloud_run_v2_service.app.uri
+  description = "Primary backend Cloud Run URI (backwards compatible)"
+  value = local.is_multi_backend ? (
+    google_cloud_run_v2_service.backends[local.primary_backend_key].uri
+  ) : (
+    length(google_cloud_run_v2_service.app) > 0 ? google_cloud_run_v2_service.app[0].uri : ""
+  )
+}
+
+output "backend_urls" {
+  description = "Map of all backend service URLs keyed by service name. Empty for single-backend apps."
+  value = local.is_multi_backend ? {
+    for name, svc in google_cloud_run_v2_service.backends : name => svc.uri
+  } : {}
 }
 
 output "lb_ip" {

--- a/providers/gcp/terraform/platform/variables.tf
+++ b/providers/gcp/terraform/platform/variables.tf
@@ -66,3 +66,15 @@ variable "iap_allowed_domain" {
   type        = string
   default     = ""
 }
+
+variable "backend_services" {
+  description = "Map of additional backend service names for multi-backend apps. Empty = single backend (backwards compatible). Keys are service names, values are unused (set to true)."
+  type        = map(bool)
+  default     = {}
+}
+
+variable "primary_backend_name" {
+  description = "Name of the primary backend service (for multi-backend apps). Used for /api/** routing in the SSO load balancer. Defaults to first key alphabetically."
+  type        = string
+  default     = ""
+}

--- a/stackramp.yaml.example
+++ b/stackramp.yaml.example
@@ -12,7 +12,7 @@ frontend:
   node_version: "20"   # optional, defaults to 20 (or reads .nvmrc)
 
 backend:
-  language: python     # python | go | node | none
+  language: python     # python | go | node | rust | none
   dir: backend         # directory containing your backend code (default: backend)
   port: 8080           # port your app listens on (default: 8080)
   memory: 512Mi        # Cloud Run memory (default: 512Mi)
@@ -21,3 +21,22 @@ backend:
 database: false        # false | postgres | mysql (Phase 2)
 
 # storage: gcs         # false | gcs — provisions a GCS bucket + injects GCS_BUCKET env var
+
+# ─── Multi-backend example ───────────────────────────────────────────────────
+# Replace the single 'backend:' block above with 'backends:' (plural) to
+# deploy multiple independent services. Each gets its own Cloud Run service.
+#
+# backends:
+#   api:
+#     language: rust
+#     dir: backend
+#     port: 8080
+#     primary: true                       # handles /api/** routing from frontend
+#     env:
+#       PREDICTOR_URL: ${backends.predictor.url}   # auto-resolved service discovery
+#   predictor:
+#     language: python
+#     dir: predictor
+#     port: 8085
+#     memory: 1Gi
+#     cpu: "2"


### PR DESCRIPTION
## Summary

Implements support for deploying multiple independent backend services from a single `stackramp.yaml`, as described in #7.

- **New `backends:` (plural) config block** — each named service gets its own Cloud Run deployment with independent language, directory, port, CPU/memory, and environment variables
- **Automatic service discovery** — each backend receives sibling service URLs as env vars (e.g. `PREDICTOR_URL`), plus support for explicit `${backends.<name>.url}` references
- **Primary backend routing** — the primary backend (first listed or marked `primary: true`) handles `/api/**` proxy routing from the frontend via Firebase Hosting rewrites or the SSO load balancer
- **Terraform multi-service provisioning** — uses `for_each` to create N Cloud Run service shells; single-backend path is unchanged for backwards compatibility
- **Full backwards compatibility** — existing apps using singular `backend:` continue to work with zero changes
- **Rust Dockerfile** — added platform-managed Rust build support
- **Preview cleanup** — handles cleanup of multi-backend PR preview services

### Config example

```yaml
name: trade-simulator

frontend:
  framework: static
  dir: frontend

backends:
  api:
    language: rust
    dir: backend
    port: 8080
    primary: true
    env:
      PREDICTOR_URL: ${backends.predictor.url}
  predictor:
    language: python
    dir: predictor
    port: 8085
    memory: 1Gi
```

### Files changed

| Area | Files |
|------|-------|
| Config parser | `platform-action/action.yml`, `platform-action/schema.json` |
| Workflows | `platform.yml`, `_backend.yml`, `_frontend.yml`, `_cleanup-preview.yml` |
| Terraform | `main.tf`, `variables.tf`, `outputs.tf` |
| Dockerfiles | `rust.Dockerfile` (new) |
| Docs | `stackramp-yaml-reference.md`, `stackramp.yaml.example` |

Closes #7

## Test plan

- [ ] Deploy an existing single-backend app (e.g. `hello-stackramp`) — verify no changes in behaviour
- [ ] Deploy a multi-backend app with `backends:` config — verify both Cloud Run services are created
- [ ] Verify service discovery env vars are injected (check Cloud Run env in GCP console)
- [ ] Verify `${backends.<name>.url}` references resolve correctly in user-defined env
- [ ] Verify Firebase Hosting `/api/**` rewrite points to the primary backend
- [ ] Verify PR preview cleanup deletes all multi-backend services
- [ ] Verify Terraform state migration works for existing apps (moved block for `app[0]`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)