### PR TITLE
fix: skip Cloud Run provisioning for frontend-only apps

### DIFF
--- a/.github/workflows/platform.yml
+++ b/.github/workflows/platform.yml
@@ -149,6 +149,7 @@ jobs:
             -var=custom_domain=${CUSTOM_DOMAIN} \
             -var=backend_domain=${BACKEND_DOMAIN} \
             -var=dns_zone_name=${{ vars.STACKRAMP_DNS_ZONE || '' }} \
+            -var=has_backend=${{ needs.parse-config.outputs.has_backend == 'true' }} \
             -var=has_storage=${{ needs.parse-config.outputs.has_storage == 'true' }} \
             -var=has_database=${{ needs.parse-config.outputs.has_database == 'true' }} \
             -var=cloudsql_connection_name=${{ vars.STACKRAMP_CLOUDSQL_CONNECTION || '' }} \
@@ -191,6 +192,7 @@ jobs:
             -var=custom_domain=${CUSTOM_DOMAIN} \
             -var=backend_domain=${BACKEND_DOMAIN} \
             -var=dns_zone_name=${{ vars.STACKRAMP_DNS_ZONE || '' }} \
+            -var=has_backend=${{ needs.parse-config.outputs.has_backend == 'true' }} \
             -var=has_storage=${{ needs.parse-config.outputs.has_storage == 'true' }} \
             -var=has_database=${{ needs.parse-config.outputs.has_database == 'true' }} \
             -var=cloudsql_connection_name=${{ vars.STACKRAMP_CLOUDSQL_CONNECTION || '' }} \

--- a/providers/gcp/terraform/platform/main.tf
+++ b/providers/gcp/terraform/platform/main.tf
@@ -17,6 +17,11 @@ moved {
   to   = google_cloud_run_v2_service_iam_member.public[0]
 }
 
+moved {
+  from = google_cloud_run_v2_service.app
+  to   = google_cloud_run_v2_service.app[0]
+}
+
 # StackRamp Per-App Infrastructure
 # Run idempotently on every deploy to ensure app infra exists.
 # Creates Firebase Hosting site + Cloud Run service for the app.
@@ -115,6 +120,7 @@ resource "google_dns_record_set" "frontend_cname" {
 # Creates the service shell — actual deployment is done by the workflow
 
 resource "google_cloud_run_v2_service" "app" {
+  count               = var.has_backend ? 1 : 0
   name                = "${var.app_name}-${var.environment}"
   location            = var.region
   project             = var.platform_project
@@ -145,10 +151,10 @@ resource "google_cloud_run_v2_service" "app" {
 
 # Allow unauthenticated access (non-SSO apps only)
 resource "google_cloud_run_v2_service_iam_member" "public" {
-  count    = var.has_sso ? 0 : 1
+  count    = var.has_backend && !var.has_sso ? 1 : 0
   project  = var.platform_project
   location = var.region
-  name     = google_cloud_run_v2_service.app.name
+  name     = google_cloud_run_v2_service.app[0].name
   role     = "roles/run.invoker"
   member   = "allUsers"
 }
@@ -200,10 +206,10 @@ resource "google_cloud_run_v2_service_iam_member" "iap_frontend_invoker" {
 
 # IAP SA invoker on backend — IAP requires run.invoker even when Cloud Run allows allUsers
 resource "google_cloud_run_v2_service_iam_member" "iap_backend_invoker" {
-  count    = var.has_sso ? 1 : 0
+  count    = var.has_sso && var.has_backend ? 1 : 0
   project  = var.platform_project
   location = var.region
-  name     = google_cloud_run_v2_service.app.name
+  name     = google_cloud_run_v2_service.app[0].name
   role     = "roles/run.invoker"
   member   = "serviceAccount:service-${data.google_project.project.number}@gcp-sa-iap.iam.gserviceaccount.com"
 }
@@ -262,14 +268,14 @@ resource "google_compute_region_network_endpoint_group" "frontend_neg" {
 }
 
 resource "google_compute_region_network_endpoint_group" "backend_neg" {
-  count                 = var.has_sso ? 1 : 0
+  count                 = var.has_sso && var.has_backend ? 1 : 0
   name                  = "${var.app_name}-be-${var.environment}-neg"
   network_endpoint_type = "SERVERLESS"
   region                = var.region
   project               = var.platform_project
 
   cloud_run {
-    service = google_cloud_run_v2_service.app.name
+    service = google_cloud_run_v2_service.app[0].name
   }
 }
 
@@ -293,7 +299,7 @@ resource "google_compute_backend_service" "frontend_bs" {
 }
 
 resource "google_compute_backend_service" "backend_bs" {
-  count                 = var.has_sso ? 1 : 0
+  count                 = var.has_sso && var.has_backend ? 1 : 0
   name                  = "${var.app_name}-be-${var.environment}-bs"
   project               = var.platform_project
   protocol              = "HTTPS"
@@ -326,9 +332,12 @@ resource "google_compute_url_map" "app" {
     name            = "paths"
     default_service = google_compute_backend_service.frontend_bs[0].id
 
-    path_rule {
-      paths   = ["/api", "/api/*"]
-      service = google_compute_backend_service.backend_bs[0].id
+    dynamic "path_rule" {
+      for_each = var.has_backend ? [1] : []
+      content {
+        paths   = ["/api", "/api/*"]
+        service = google_compute_backend_service.backend_bs[0].id
+      }
     }
   }
 }
@@ -402,7 +411,7 @@ resource "google_iap_web_backend_service_iam_member" "frontend_access" {
 }
 
 resource "google_iap_web_backend_service_iam_member" "backend_access" {
-  count               = var.has_sso ? 1 : 0
+  count               = var.has_sso && var.has_backend ? 1 : 0
   project             = var.platform_project
   web_backend_service = google_compute_backend_service.backend_bs[0].name
   role                = "roles/iap.httpsResourceAccessor"

--- a/providers/gcp/terraform/platform/outputs.tf
+++ b/providers/gcp/terraform/platform/outputs.tf
@@ -14,7 +14,7 @@ output "frontend_url" {
 
 output "backend_url" {
   description = "Backend Cloud Run URI"
-  value       = google_cloud_run_v2_service.app.uri
+  value       = var.has_backend ? google_cloud_run_v2_service.app[0].uri : ""
 }
 
 output "lb_ip" {

--- a/providers/gcp/terraform/platform/variables.tf
+++ b/providers/gcp/terraform/platform/variables.tf
@@ -37,6 +37,12 @@ variable "backend_domain" {
   default     = ""
 }
 
+variable "has_backend" {
+  description = "Whether the app has a backend service. When false, Cloud Run is not provisioned."
+  type        = bool
+  default     = false
+}
+
 variable "has_storage" {
   description = "Whether to provision a GCS bucket for this app"
   type        = bool


### PR DESCRIPTION
## Summary
- Adds `has_backend` terraform variable, gating `google_cloud_run_v2_service.app` and all dependent resources (IAM binding, NEG, backend service, IAP access) behind it
- Passes the existing `has_backend` output from the config parser to terraform in both dev and prod applies
- Frontend-only apps no longer create unnecessary Cloud Run infrastructure
- Includes `moved` block for safe state migration of existing apps

## Context
Frontend-only apps (no `backend` section in `stackramp.yaml`) were failing on GCP projects with org policies restricting `allUsers` IAM bindings — the platform was unconditionally creating a Cloud Run service + public IAM member even when no backend was defined.

Fixes #15

## Test plan
- [ ] Deploy a frontend-only app (e.g. `bobby-test-repo`) — should provision Firebase Hosting only, no Cloud Run
- [ ] Deploy a full-stack app (frontend + backend) — should behave as before
- [ ] Verify existing apps with backends get the `moved` block migration cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)