### PR TITLE
fix: support framework: static without Node.js build step

### DIFF
--- a/.github/workflows/_frontend.yml
+++ b/.github/workflows/_frontend.yml
@@ -90,6 +90,7 @@ jobs:
           service_account: ${{ inputs.service_account }}
 
       - name: Detect Node version
+        if: inputs.frontend_framework != 'static'
         id: node-version
         run: |
           if [ -f "${{ inputs.frontend_dir }}/.nvmrc" ]; then
@@ -99,6 +100,7 @@ jobs:
           fi
 
       - name: Setup Node.js
+        if: inputs.frontend_framework != 'static'
         uses: actions/setup-node@v4
         with:
           node-version: ${{ steps.node-version.outputs.version }}
@@ -106,12 +108,20 @@ jobs:
           cache-dependency-path: "**/package-lock.json"
 
       - name: Install & Build
+        if: inputs.frontend_framework != 'static'
         env:
           VITE_API_URL: ${{ inputs.backend_url }}
         run: |
           cd ${{ inputs.frontend_dir }}
           npm ci
           npm run build
+
+      - name: Copy static files to dist
+        if: inputs.frontend_framework == 'static'
+        run: |
+          mkdir -p ${{ inputs.frontend_dir }}/dist
+          cp -r ${{ inputs.frontend_dir }}/* ${{ inputs.frontend_dir }}/dist/ 2>/dev/null || true
+          rm -rf ${{ inputs.frontend_dir }}/dist/dist
 
       # ── SSO path: Docker + Cloud Run ──────────────────────────────────────
       - name: Configure Docker (SSO)


### PR DESCRIPTION
## Summary
- Skips Node.js setup, npm cache, and npm ci/build for `framework: static` frontends
- Copies static source files to `dist/` so Firebase Hosting serves from the same path as built frameworks

## Context
Static frontends have no `package.json` or `package-lock.json`, causing `setup-node@v4` cache resolution to fail and `npm ci` to error. The firebase.json already points at `frontend/dist`, so copying files there keeps everything consistent.

## Test plan
- [ ] Deploy a `framework: static` app (e.g. `bobby-test-repo`) — should skip Node, copy files, deploy to Firebase
- [ ] Deploy a `framework: react` app — should behave as before (Node + npm build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)