### PR TITLE
feat: add framework: next support for SSO deployments

### DIFF
--- a/.github/workflows/_frontend.yml
+++ b/.github/workflows/_frontend.yml
@@ -132,9 +132,14 @@ jobs:
         if: inputs.sso == 'true' && inputs.is_pr != 'true'
         run: |
           IMAGE="${{ inputs.region }}-docker.pkg.dev/${{ inputs.platform_project }}/stackramp-images/${{ inputs.app_name }}-fe:${{ github.sha }}"
+          if [ "${{ inputs.frontend_framework }}" = "next" ]; then
+            DOCKERFILE=".stackramp/platform-action/dockerfiles/node-next.Dockerfile"
+          else
+            DOCKERFILE=".stackramp/platform-action/dockerfiles/nginx-spa.Dockerfile"
+          fi
           docker build \
             -t "$IMAGE" \
-            -f .stackramp/platform-action/dockerfiles/nginx-spa.Dockerfile \
+            -f "$DOCKERFILE" \
             ${{ inputs.frontend_dir }}/
           docker push "$IMAGE"
           echo "IMAGE=$IMAGE" >> $GITHUB_ENV
@@ -143,11 +148,12 @@ jobs:
         if: inputs.sso == 'true' && inputs.is_pr != 'true'
         id: deploy-sso
         run: |
+          FRONTEND_PORT=${{ inputs.frontend_framework == 'next' && '3000' || '8080' }}
           gcloud run deploy "${{ inputs.app_name }}-fe-${{ inputs.environment }}" \
             --image="$IMAGE" \
             --region="${{ inputs.region }}" \
             --platform=managed \
-            --port=8080 \
+            --port=$FRONTEND_PORT \
             --allow-unauthenticated \
             --ingress=internal-and-cloud-load-balancing \
             --project="${{ inputs.platform_project }}"

--- a/platform-action/dockerfiles/node-next.Dockerfile
+++ b/platform-action/dockerfiles/node-next.Dockerfile
@@ -1,0 +1,11 @@
+# Serves a Next.js app in standalone mode on port 3000.
+# Build context must be the frontend directory (containing .next/ after npm run build).
+FROM node:20-alpine
+WORKDIR /app
+COPY .next/standalone ./
+COPY .next/static ./.next/static
+COPY public ./public
+EXPOSE 3000
+ENV PORT=3000
+ENV HOSTNAME="0.0.0.0"
+CMD ["node", "server.js"]


### PR DESCRIPTION
## Summary
- Adds `node-next.Dockerfile` for Next.js standalone mode (node server.js on port 3000)
- `_frontend.yml` selects the correct Dockerfile based on `frontend_framework`
- Cloud Run deploy uses port 3000 for Next.js, 8080 for nginx-based frameworks

## Usage
In your `stackramp.yaml`:
```yaml
frontend:
  framework: next
  dir: frontend
  sso: true
```

Consuming repos must set `output: 'standalone'` in their `next.config.js`/`next.config.ts`.

## Test plan
- [ ] Deploy weather-app with `framework: next` + SSO — should build standalone and deploy to Cloud Run
- [ ] Deploy a `framework: react` app with SSO — should still use nginx-spa Dockerfile as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)