### PR TITLE
feat: use private IP for Cloud SQL with VPC connector

### DIFF
--- a/.github/workflows/_backend.yml
+++ b/.github/workflows/_backend.yml
@@ -60,6 +60,11 @@ on:
         required: false
         default: ""
         description: "Cloud SQL instance connection name (project:region:instance). Required when the app has a database."
+      vpc_connector:
+        type: string
+        required: false
+        default: ""
+        description: "Serverless VPC Access Connector name for Cloud SQL private IP connectivity."
       database_secret_name:
         type: string
         required: false
@@ -194,6 +199,7 @@ jobs:
             DEPLOY_FLAGS+=(--allow-unauthenticated --ingress=all)
           fi
           [ -n "$SECRET_REFS" ] && DEPLOY_FLAGS+=(--set-secrets="$SECRET_REFS")
+          [ -n "${{ inputs.vpc_connector }}" ] && DEPLOY_FLAGS+=(--vpc-connector="${{ inputs.vpc_connector }}" --vpc-egress=private-ranges-only)
           [ -n "${{ inputs.cloudsql_connection_name }}" ] && DEPLOY_FLAGS+=(--add-cloudsql-instances="${{ inputs.cloudsql_connection_name }}")
 
           gcloud run deploy "$SERVICE_NAME" "${DEPLOY_FLAGS[@]}"

--- a/.github/workflows/platform.yml
+++ b/.github/workflows/platform.yml
@@ -266,6 +266,7 @@ jobs:
       frontend_url: ${{ needs.provision.outputs.frontend_url_dev }}
       storage_bucket: ${{ needs.provision.outputs.storage_bucket_dev }}
       cloudsql_connection_name: ${{ vars.STACKRAMP_CLOUDSQL_CONNECTION || '' }}
+      vpc_connector: ${{ vars.STACKRAMP_VPC_CONNECTOR || '' }}
       database_secret_name: ${{ needs.provision.outputs.database_secret_name_dev }}
       sso: ${{ needs.parse-config.outputs.has_sso }}
 
@@ -323,5 +324,6 @@ jobs:
       frontend_url: ${{ needs.provision.outputs.frontend_url_prod }}
       storage_bucket: ${{ needs.provision.outputs.storage_bucket_prod }}
       cloudsql_connection_name: ${{ vars.STACKRAMP_CLOUDSQL_CONNECTION || '' }}
+      vpc_connector: ${{ vars.STACKRAMP_VPC_CONNECTOR || '' }}
       database_secret_name: ${{ needs.provision.outputs.database_secret_name_prod }}
       sso: ${{ needs.parse-config.outputs.has_sso }}

--- a/providers/gcp/terraform/bootstrap/main.tf
+++ b/providers/gcp/terraform/bootstrap/main.tf
@@ -48,6 +48,8 @@ resource "google_project_service" "apis" {
     "dns.googleapis.com",
     "compute.googleapis.com",
     "iap.googleapis.com",
+    "servicenetworking.googleapis.com",
+    "vpcaccess.googleapis.com",
   ])
 
   service            = each.value
@@ -94,6 +96,8 @@ resource "google_project_iam_member" "platform_roles" {
     "roles/storage.admin",
     "roles/dns.admin",
     "roles/compute.loadBalancerAdmin",
+    "roles/compute.networkAdmin",
+    "roles/vpcaccess.admin",
     "roles/iap.admin",
   ])
 
@@ -185,6 +189,58 @@ resource "google_secret_manager_secret_iam_member" "platform_run_access" {
   member    = "serviceAccount:${data.google_project.platform.number}-compute@developer.gserviceaccount.com"
 }
 
+# ── VPC Network (for Cloud SQL private IP) ───────────────────────────────────
+# Cloud SQL with private IP requires a VPC with service networking peering.
+# Cloud Run connects via a Serverless VPC Access Connector.
+
+resource "google_compute_network" "platform" {
+  count                           = var.enable_postgres ? 1 : 0
+  name                            = "stackramp-vpc-${var.environment}"
+  project                         = local.platform_project
+  routing_mode                    = "GLOBAL"
+  auto_create_subnetworks         = false
+  delete_default_routes_on_create = false
+  depends_on                      = [google_project_service.apis]
+}
+
+resource "google_compute_subnetwork" "platform" {
+  count                    = var.enable_postgres ? 1 : 0
+  name                     = "stackramp-subnet-${var.environment}"
+  project                  = local.platform_project
+  region                   = var.region
+  network                  = google_compute_network.platform[0].name
+  ip_cidr_range            = "10.0.0.0/20"
+  private_ip_google_access = true
+}
+
+resource "google_compute_global_address" "private_ip_range" {
+  count         = var.enable_postgres ? 1 : 0
+  name          = "stackramp-sql-private-ip-${var.environment}"
+  purpose       = "VPC_PEERING"
+  address_type  = "INTERNAL"
+  prefix_length = 16
+  network       = google_compute_network.platform[0].id
+}
+
+resource "google_service_networking_connection" "private_vpc" {
+  count                   = var.enable_postgres ? 1 : 0
+  network                 = google_compute_network.platform[0].id
+  service                 = "servicenetworking.googleapis.com"
+  reserved_peering_ranges = [google_compute_global_address.private_ip_range[0].name]
+}
+
+resource "google_vpc_access_connector" "platform" {
+  count         = var.enable_postgres ? 1 : 0
+  name          = "stackramp-vpc-${var.environment}"
+  project       = local.platform_project
+  region        = var.region
+  network       = google_compute_network.platform[0].name
+  ip_cidr_range = "10.8.0.0/28"
+  min_instances = 2
+  max_instances = 3
+  depends_on    = [google_project_service.apis]
+}
+
 # ── Shared Cloud SQL Postgres Instance ────────────────────────────────────────
 # One instance per environment, shared across all apps. Each app that declares
 # `database: postgres` in stackramp.yaml gets its own database + user within
@@ -205,12 +261,13 @@ resource "google_sql_database_instance" "platform" {
     }
 
     ip_configuration {
-      ipv4_enabled = true
+      ipv4_enabled    = false
+      private_network = google_compute_network.platform[0].id
     }
   }
 
   deletion_protection = true
-  depends_on          = [google_project_service.apis]
+  depends_on          = [google_service_networking_connection.private_vpc]
 }
 
 resource "google_service_account_iam_member" "wif_binding" {

--- a/providers/gcp/terraform/bootstrap/outputs.tf
+++ b/providers/gcp/terraform/bootstrap/outputs.tf
@@ -43,6 +43,11 @@ output "cloudsql_instance_name" {
   value       = var.enable_postgres ? google_sql_database_instance.platform[0].name : ""
 }
 
+output "vpc_connector_name" {
+  description = "Set as GitHub Variable: STACKRAMP_VPC_CONNECTOR (only when enable_postgres = true)"
+  value       = var.enable_postgres ? google_vpc_access_connector.platform[0].name : ""
+}
+
 output "iap_enabled" {
   description = "Whether IAP was configured (iap_allowed_domain was set)"
   value       = var.iap_allowed_domain != ""
@@ -63,7 +68,7 @@ output "github_variables_summary" {
     │ STACKRAMP_WIF_PROVIDER = ${google_iam_workload_identity_pool_provider.github.name}
     │ STACKRAMP_SA_EMAIL     = ${google_service_account.platform_cicd.email}
     ${var.base_domain != "" ? "│ STACKRAMP_BASE_DOMAIN  = ${var.base_domain}\n    │ STACKRAMP_DNS_ZONE     = ${replace(var.base_domain, ".", "-")}" : ""}
-    ${var.enable_postgres ? "│ STACKRAMP_CLOUDSQL_CONNECTION = ${google_sql_database_instance.platform[0].connection_name}" : ""}
+    ${var.enable_postgres ? "│ STACKRAMP_CLOUDSQL_CONNECTION = ${google_sql_database_instance.platform[0].connection_name}\n    │ STACKRAMP_VPC_CONNECTOR       = ${google_vpc_access_connector.platform[0].name}" : ""}
     ${var.iap_allowed_domain != "" ? "│ STACKRAMP_IAP_DOMAIN          = ${var.iap_allowed_domain}" : ""}
     │                                                                    │
     └──────────────────────────────────────────────────────────────────────┘


### PR DESCRIPTION
## Summary
- Bootstrap provisions VPC network, subnet, private IP peering, and Serverless VPC Access Connector when `enable_postgres = true`
- Cloud SQL uses `ipv4_enabled = false` with `private_network` — compliant with `constraints/sql.restrictPublicIp` org policy
- Backend Cloud Run deploys with `--vpc-connector` and `--vpc-egress=private-ranges-only`
- New `STACKRAMP_VPC_CONNECTOR` GitHub Variable output from bootstrap

## After merging
Re-run bootstrap for each environment. The bootstrap will create the VPC resources and recreate Cloud SQL with private IP. Then set the new `STACKRAMP_VPC_CONNECTOR` GitHub Variable.

**Note:** Existing Cloud SQL instances with public IP will need to be recreated (or migrated) since switching from public to private IP is a destructive change.

## Test plan
- [ ] Run bootstrap with `enable_postgres = true` on a fresh environment
- [ ] Verify Cloud SQL has no public IP
- [ ] Deploy a backend app with `database: postgres` — verify it connects via VPC connector

🤖 Generated with [Claude Code](https://claude.com/claude-code)