### PR TITLE
chore: trigger dashboard redeploy

### DIFF
--- a/dashboard/frontend/package.json
+++ b/dashboard/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "stackramp-dashboard",
   "private": true,
-  "version": "1.0.0",
+  "version": "1.0.1",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
Version bump to trigger full redeploy — Terraform will clean up orphaned LB resources.