### PR TITLE
Forward IAP user identity to backend via X-Stackramp-* headers

### DIFF
--- a/platform-action/proxy/main.go
+++ b/platform-action/proxy/main.go
@@ -64,6 +64,17 @@ func main() {
 				}
 			}
 
+			// Forward the IAP-authenticated user identity so backends can do
+			// user-aware authorisation. We re-key the headers under X-Stackramp-*
+			// to avoid Cloud Run's auth layer intercepting the original IAP JWT
+			// (see comment on the fresh-request rationale above).
+			if email := r.Header.Get("X-Goog-Authenticated-User-Email"); email != "" {
+				proxyReq.Header.Set("X-Stackramp-User-Email", strings.TrimPrefix(email, "accounts.google.com:"))
+			}
+			if id := r.Header.Get("X-Goog-Authenticated-User-Id"); id != "" {
+				proxyReq.Header.Set("X-Stackramp-User-Id", strings.TrimPrefix(id, "accounts.google.com:"))
+			}
+
 			resp, err := http.DefaultClient.Do(proxyReq)
 			if err != nil {
 				log.Printf("ERROR: backend request: %v", err)


### PR DESCRIPTION
## Summary

- The SSO proxy currently strips all IAP headers when forwarding requests to the backend (necessary because Cloud Run's auth layer on the backend rejects mismatched IAP JWTs). As a side effect, **backends have no way to know who the authenticated human user is.**
- This adds two re-keyed pass-through headers — `X-Stackramp-User-Email` and `X-Stackramp-User-Id` — sourced from IAP's `X-Goog-Authenticated-User-*` headers (with the `accounts.google.com:` prefix stripped).
- Re-keying avoids the same Cloud Run auth-layer collision that prompted the fresh-request pattern in the first place.

## Why now

Resource-Planner-style "only certain users can see this route" use cases need this. Without it, the backend either trusts every authenticated request equally (current behaviour) or has to redo IAP from scratch.

## Trust model

Unchanged in spirit:

- Proxy → backend traffic is already authenticated via the service-account Bearer token issued from the GCE metadata server.
- Cloud Run ingress for the backend is `internal-and-cloud-load-balancing` — external clients cannot reach the backend, so they cannot spoof `X-Stackramp-User-Email` directly.
- Backends now opt in to user-aware logic by reading the new headers; existing backends that ignore them are unaffected.

## Test plan

- [ ] Build/vet (verified locally — `go build ./...` + `go vet ./...` clean)
- [ ] Deploy to a stackramp app with SSO + backend (e.g. TT-Tools) and confirm the backend sees `X-Stackramp-User-Email` matching the SSO'd user
- [ ] Confirm existing SSO apps without consumer code for the new headers continue to function

🤖 Generated with [Claude Code](https://claude.com/claude-code)