### PR TITLE
[gopher] GCS bucket support in stackramp.yaml (storage.buckets block)

### DIFF
--- a/.github/workflows/_backend.yml
+++ b/.github/workflows/_backend.yml
@@ -50,6 +50,11 @@ on:
         type: string
         required: false
         default: ""
+      bucket_env_json:
+        type: string
+        required: false
+        default: "{}"
+        description: "JSON map of logical bucket name -> resolved GCS bucket name (storage.buckets block). Each entry is injected as env var BUCKET_<NAME_UPPER>."
       extra_env_vars:
         type: string
         required: false
@@ -197,13 +202,27 @@ jobs:
             --wait
 
       - name: Deploy to Cloud Run
+        env:
+          # JSON map passed via env to avoid quote-handling issues inline.
+          BUCKET_ENV_JSON: ${{ inputs.bucket_env_json }}
         run: |
           SERVICE_NAME="${{ inputs.app_name }}-${{ inputs.environment }}"
 
           # ── Env vars (non-secret config) ────────────────────────────────────
           ENV_VARS="ENVIRONMENT=${{ inputs.environment }},APP_NAME=${{ inputs.app_name }},FRONTEND_URL=${{ inputs.frontend_url }}"
+          # Legacy single bucket (storage: gcs) — kept for back-compat.
           if [ -n "${{ inputs.storage_bucket }}" ]; then
             ENV_VARS="${ENV_VARS},GCS_BUCKET=${{ inputs.storage_bucket }}"
+          fi
+          # storage.buckets block — inject one BUCKET_<NAME_UPPER>=<bucketname>
+          # per declared bucket. Mirrors the platform_secrets discovery pattern:
+          # iterate the resolved map and append each key/value as an env var.
+          if [ -n "$BUCKET_ENV_JSON" ] && [ "$BUCKET_ENV_JSON" != "{}" ] && [ "$BUCKET_ENV_JSON" != "null" ]; then
+            while IFS=$'\t' read -r LOGICAL BUCKET; do
+              [ -z "$LOGICAL" ] && continue
+              VAR_NAME="BUCKET_$(echo "$LOGICAL" | tr '[:lower:]-' '[:upper:]_')"
+              ENV_VARS="${ENV_VARS},${VAR_NAME}=${BUCKET}"
+            done < <(echo "$BUCKET_ENV_JSON" | jq -r 'to_entries[] | "\(.key)\t\(.value)"')
           fi
           if [ -n "${{ inputs.extra_env_vars }}" ]; then
             ENV_VARS="${ENV_VARS},${{ inputs.extra_env_vars }}"

--- a/.github/workflows/platform.yml
+++ b/.github/workflows/platform.yml
@@ -86,6 +86,10 @@ jobs:
         uses: bobbydeveaux/stackramp/platform-action@main
         with:
           config_path: ${{ inputs.config_path }}
+        env:
+          # Used by the action to pre-validate resolved GCS bucket-name length
+          # ({project}-{app}-{env}-{name} must be <= 63 chars).
+          STACKRAMP_PROJECT: ${{ vars.STACKRAMP_PROJECT }}
 
       - name: Detect changes
         id: changes

--- a/.github/workflows/platform.yml
+++ b/.github/workflows/platform.yml
@@ -60,6 +60,7 @@ jobs:
       custom_domain: ${{ steps.config.outputs.custom_domain }}
       has_storage: ${{ steps.config.outputs.has_storage }}
       storage_type: ${{ steps.config.outputs.storage_type }}
+      storage_buckets: ${{ steps.config.outputs.storage_buckets }}
       has_sso: ${{ steps.config.outputs.has_sso }}
       min_instances: ${{ steps.config.outputs.min_instances }}
       migrate_command: ${{ steps.config.outputs.migrate_command }}
@@ -167,6 +168,8 @@ jobs:
       site_id_prod: ${{ steps.tf-out-prod.outputs.site_id }}
       storage_bucket_dev: ${{ steps.tf-out-dev.outputs.storage_bucket }}
       storage_bucket_prod: ${{ steps.tf-out-prod.outputs.storage_bucket }}
+      bucket_env_json_dev: ${{ steps.tf-out-dev.outputs.bucket_env_json }}
+      bucket_env_json_prod: ${{ steps.tf-out-prod.outputs.bucket_env_json }}
       database_secret_name_dev: ${{ steps.tf-out-dev.outputs.database_secret_name }}
       database_secret_name_prod: ${{ steps.tf-out-prod.outputs.database_secret_name }}
     steps:
@@ -195,6 +198,10 @@ jobs:
 
       - name: Terraform apply (dev)
         working-directory: .stackramp/providers/gcp/terraform/platform
+        env:
+          # buckets_json carries quotes/spaces, so it is passed via env and a
+          # separate quoted -var argument rather than the unquoted TF_VARS blob.
+          BUCKETS_JSON: ${{ needs.parse-config.outputs.storage_buckets }}
         run: |
           # For auto-generated subdomains (app.base_domain), dev gets app.dev.base_domain.
           # Explicit domains (e.g. stackramp.io set directly in stackramp.yaml) are left as-is.
@@ -223,7 +230,7 @@ jobs:
             -var=iap_allowed_domain=${{ vars.STACKRAMP_IAP_DOMAIN || '' }} \
             -var=frontend_sa_email=${{ vars.STACKRAMP_FRONTEND_SA || '' }}"
 
-          terraform apply -auto-approve $TF_VARS
+          terraform apply -auto-approve $TF_VARS -var="buckets_json=${BUCKETS_JSON:-[]}"
 
       - name: Capture dev outputs
         id: tf-out-dev
@@ -233,6 +240,7 @@ jobs:
           echo "frontend_url=$(terraform output -raw frontend_url 2>/dev/null || echo '')" >> $GITHUB_OUTPUT
           echo "site_id=$(terraform output -raw site_id 2>/dev/null || echo '')" >> $GITHUB_OUTPUT
           echo "storage_bucket=$(terraform output -raw storage_bucket 2>/dev/null || echo '')" >> $GITHUB_OUTPUT
+          echo "bucket_env_json=$(terraform output -raw bucket_env_json 2>/dev/null || echo '{}')" >> $GITHUB_OUTPUT
           echo "database_secret_name=$(terraform output -raw database_secret_name 2>/dev/null || echo '')" >> $GITHUB_OUTPUT
 
       - name: Terraform init (prod)
@@ -246,6 +254,8 @@ jobs:
       - name: Terraform apply (prod — main branch only)
         if: github.ref == 'refs/heads/main' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
         working-directory: .stackramp/providers/gcp/terraform/platform
+        env:
+          BUCKETS_JSON: ${{ needs.parse-config.outputs.storage_buckets }}
         run: |
           CUSTOM_DOMAIN="${{ needs.parse-config.outputs.custom_domain }}"
           BACKEND_DOMAIN=""
@@ -267,7 +277,7 @@ jobs:
             -var=iap_allowed_domain=${{ vars.STACKRAMP_IAP_DOMAIN || '' }} \
             -var=frontend_sa_email=${{ vars.STACKRAMP_FRONTEND_SA || '' }}"
 
-          terraform apply -auto-approve $TF_VARS
+          terraform apply -auto-approve $TF_VARS -var="buckets_json=${BUCKETS_JSON:-[]}"
 
       - name: Capture prod outputs
         id: tf-out-prod
@@ -278,6 +288,7 @@ jobs:
           echo "frontend_url=$(terraform output -raw frontend_url 2>/dev/null || echo '')" >> $GITHUB_OUTPUT
           echo "site_id=$(terraform output -raw site_id 2>/dev/null || echo '')" >> $GITHUB_OUTPUT
           echo "storage_bucket=$(terraform output -raw storage_bucket 2>/dev/null || echo '')" >> $GITHUB_OUTPUT
+          echo "bucket_env_json=$(terraform output -raw bucket_env_json 2>/dev/null || echo '{}')" >> $GITHUB_OUTPUT
           echo "database_secret_name=$(terraform output -raw database_secret_name 2>/dev/null || echo '')" >> $GITHUB_OUTPUT
 
   # ─────────────────────────────────────────────────────────────────────────────
@@ -336,6 +347,7 @@ jobs:
       service_account: ${{ vars.STACKRAMP_SA_EMAIL }}
       frontend_url: ${{ needs.provision.outputs.frontend_url_dev }}
       storage_bucket: ${{ needs.provision.outputs.storage_bucket_dev }}
+      bucket_env_json: ${{ needs.provision.outputs.bucket_env_json_dev }}
       cloudsql_connection_name: ${{ vars.STACKRAMP_CLOUDSQL_CONNECTION || '' }}
       vpc_connector: ${{ vars.STACKRAMP_VPC_CONNECTOR || '' }}
       database_secret_name: ${{ needs.provision.outputs.database_secret_name_dev }}
@@ -401,6 +413,7 @@ jobs:
       service_account: ${{ vars.STACKRAMP_SA_EMAIL }}
       frontend_url: ${{ needs.provision.outputs.frontend_url_prod }}
       storage_bucket: ${{ needs.provision.outputs.storage_bucket_prod }}
+      bucket_env_json: ${{ needs.provision.outputs.bucket_env_json_prod }}
       cloudsql_connection_name: ${{ vars.STACKRAMP_CLOUDSQL_CONNECTION || '' }}
       vpc_connector: ${{ vars.STACKRAMP_VPC_CONNECTOR || '' }}
       database_secret_name: ${{ needs.provision.outputs.database_secret_name_prod }}

--- a/INTEGRATION.md
+++ b/INTEGRATION.md
@@ -344,14 +344,14 @@ backend:
 storage:
   buckets:
     - name: downloads        # -> env var BUCKET_DOWNLOADS
-      access: private        # private (default) | public
+      access: private        # private only — public is not yet supported
       signed_urls: true      # keyless V4 signed URLs (signBlob, no key file)
       lifecycle_days: 2      # delete objects after 2 days (0 = no rule)
 ```
 
-For each entry the platform provisions a bucket named `{project}-{app}-{env}-{name}` (e.g. `bj-platform-dev-my-app-dev-downloads`) with uniform bucket-level access, grants the runtime SA `roles/storage.objectAdmin` scoped to that bucket, and injects the bucket name as `BUCKET_<NAME_UPPER>` (hyphens become underscores).
+For each entry the platform provisions a **private** bucket named `{project}-{app}-{env}-{name}` (e.g. `bj-platform-dev-my-app-dev-downloads`) with uniform bucket-level access, grants the runtime SA `roles/storage.objectAdmin` scoped to that bucket, and injects the bucket name as `BUCKET_<NAME_UPPER>` (hyphens become underscores). The resolved name must be 63 characters or fewer (the GCS limit) — longer names fail validation early, so keep logical names short.
 
-- **`access: private`** (default) turns public access prevention ON — anonymous reads are rejected.
+- **`access`** — only `private` (the default) is supported: public access prevention is enforced and anonymous reads are rejected. `access: public` is reserved for a future release and is currently a hard validation error (public buckets / CDN fronting are out of scope).
 - **`signed_urls: true`** grants the runtime SA `roles/iam.serviceAccountTokenCreator` on itself, so the backend can mint V4 signed URLs via the IAM `signBlob` API with **no downloaded key file**. This is the keyless signing pattern: build the signer from the runtime credentials, set `GoogleAccessID` to the runtime SA email, and the IAM credentials API signs the bytes.
 - **`lifecycle_days`** adds an age-based delete lifecycle rule when greater than 0.
 

--- a/INTEGRATION.md
+++ b/INTEGRATION.md
@@ -71,7 +71,7 @@ domain: my-app.yourdomain.com # optional custom domain
 
 database: false               # false | postgres | mysql (default: false)
 
-storage: false                # false | gcs (default: false)
+storage: false                # false | gcs | { buckets: [...] } (default: false)
 ```
 
 **Frontend-only example:**
@@ -239,7 +239,8 @@ The following env vars are injected into every Cloud Run service at deploy time:
 | `ENVIRONMENT` | `dev`, `prod`, or `pr-{number}` |
 | `APP_NAME` | Value of `name` in `stackramp.yaml` |
 | `FRONTEND_URL` | Firebase Hosting URL for the same environment |
-| `STORAGE_BUCKET` | GCS bucket name (only if `storage: gcs`) |
+| `GCS_BUCKET` | GCS bucket name (only if `storage: gcs`, the legacy scalar form) |
+| `BUCKET_<NAME>` | One per `storage.buckets` entry, e.g. `BUCKET_DOWNLOADS` (block form) |
 | `DATABASE_SECRET_NAME` | Secret Manager secret name for DB URL (only if `database:` is set) |
 
 ---
@@ -313,7 +314,11 @@ On every PR:
 
 ## GCS Storage
 
-Set `storage: gcs` in `stackramp.yaml` to provision a GCS bucket per environment.
+StackRamp provisions private GCS buckets for your app, wires the Cloud Run runtime service account's IAM, and injects the bucket name(s) as env vars. No manual GCP steps. There are two forms.
+
+### Legacy scalar form
+
+Set `storage: gcs` to provision a single bucket named `{app}-data-{env}`. The `GCS_BUCKET` env var is injected into the Cloud Run service at deploy time, and the runtime SA is granted `roles/storage.objectAdmin` on it.
 
 ```yaml
 name: my-app
@@ -325,7 +330,32 @@ backend:
 storage: gcs
 ```
 
-The bucket name follows the convention `{project}-{app}-{env}` (e.g. `bj-platform-dev-my-app-dev`). The `STORAGE_BUCKET` env var is injected into the Cloud Run service at deploy time.
+### Block form (one or more named buckets)
+
+Declare named buckets under `storage.buckets`:
+
+```yaml
+name: my-app
+
+backend:
+  language: go
+  dir: backend
+
+storage:
+  buckets:
+    - name: downloads        # -> env var BUCKET_DOWNLOADS
+      access: private        # private (default) | public
+      signed_urls: true      # keyless V4 signed URLs (signBlob, no key file)
+      lifecycle_days: 2      # delete objects after 2 days (0 = no rule)
+```
+
+For each entry the platform provisions a bucket named `{project}-{app}-{env}-{name}` (e.g. `bj-platform-dev-my-app-dev-downloads`) with uniform bucket-level access, grants the runtime SA `roles/storage.objectAdmin` scoped to that bucket, and injects the bucket name as `BUCKET_<NAME_UPPER>` (hyphens become underscores).
+
+- **`access: private`** (default) turns public access prevention ON — anonymous reads are rejected.
+- **`signed_urls: true`** grants the runtime SA `roles/iam.serviceAccountTokenCreator` on itself, so the backend can mint V4 signed URLs via the IAM `signBlob` API with **no downloaded key file**. This is the keyless signing pattern: build the signer from the runtime credentials, set `GoogleAccessID` to the runtime SA email, and the IAM credentials API signs the bytes.
+- **`lifecycle_days`** adds an age-based delete lifecycle rule when greater than 0.
+
+**Back-compat:** `storage: false` and `storage: gcs` are unchanged. Use either the scalar form or the block form, not both in one file.
 
 ---
 

--- a/docs/requirements/stackramp-gcs-storage.md
+++ b/docs/requirements/stackramp-gcs-storage.md
@@ -1,0 +1,54 @@
+# Requirement: GCS bucket support in `stackramp.yaml`
+
+Status: proposed · Priority: high (blocks the AI Security Posture paid-download launch) · Owner: StackRamp platform team
+
+## Problem
+
+Apps need private object storage. The immediate driver: the AI Security Posture site (`aiposture`) must serve a paid PDF behind an authenticated, time-limited download, so the file must live in a **private** bucket that the backend can read and hand out **expiring signed URLs** for. There is no way to request this today - `storage:` effectively only supports `false`, and `database:` covers Postgres. Apps are blocked on provisioning + IAM-wiring a bucket by hand, outside the platform.
+
+## Goal
+
+Let an app declare one or more private GCS buckets in `stackramp.yaml`. On deploy the platform should: provision the bucket(s), grant the app's Cloud Run runtime service account the right access, inject the bucket name(s) to the backend as env vars, and - optionally - enable the SA to mint V4 signed URLs **without a downloaded key file**.
+
+## Proposed schema
+
+Extend `storage:` from a scalar to an optional block (keep the scalar forms working for back-compat):
+
+```yaml
+storage:
+  buckets:
+    - name: downloads        # logical name -> env var BUCKET_DOWNLOADS
+      access: private        # private (default) | public
+      signed_urls: true      # grant the SA signBlob so the app can mint V4 signed URLs
+      lifecycle_days: 0      # optional object TTL in days (0 = no lifecycle rule)
+```
+
+Back-compat: `storage: false` and `storage: gcs` continue to behave as they do now.
+
+## Platform behaviour
+
+1. **Provision** a bucket per entry, e.g. `gs://{project}-{app}-{env}-{name}`, with uniform bucket-level access and public access prevention ON (when `access: private`).
+2. **IAM**: grant the app's Cloud Run runtime SA `roles/storage.objectAdmin` (or `objectViewer` if you later add a read-only flag) scoped to that bucket only.
+3. **Signed URLs** (`signed_urls: true`): grant the SA `roles/iam.serviceAccountTokenCreator` **on itself** so the backend can call `signBlob` and generate V4 signed URLs with no exported key file (the keyless signing pattern). Without this flag, skip it.
+4. **Env injection**: expose each bucket name to the backend as `BUCKET_{NAME_UPPER}` (e.g. `BUCKET_DOWNLOADS`), the same way `platform_secrets` values are injected.
+5. **Lifecycle**: if `lifecycle_days > 0`, add an age-based delete lifecycle rule.
+6. **Teardown**: deleting the block removes the bucket (guard with the usual destroy protections; consider `prevent_destroy` / a confirm for non-empty buckets).
+
+## Acceptance criteria
+
+- A `stackramp.yaml` containing the `storage.buckets` block provisions the bucket(s) on the next deploy with no manual GCP steps.
+- The Cloud Run SA can read/write objects in its bucket, and - when `signed_urls: true` - generate a working V4 signed URL **with no SA key file** (verify by issuing one and fetching it).
+- `access: private` buckets reject anonymous access (public access prevention enforced).
+- `BUCKET_<NAME>` env var is present in the running service.
+- `storage: false` apps are unaffected.
+- Documented in `docs/stackramp-yaml-reference.md` and `docs/INTEGRATION.md`.
+
+## Out of scope (for now)
+
+- Cross-app bucket sharing.
+- Non-GCS providers (S3/Azure) - revisit when the provider abstraction is generalised.
+- CDN / public-bucket fronting (only needed if `access: public` is used for assets).
+
+## Consumer reference (what `aiposture` will do with it)
+
+The backend will: store the playbook PDF/bundle in the private `downloads` bucket; on a verified, unexpired HMAC download token, mint a short-lived (e.g. 5 min) V4 signed URL and redirect the buyer to it. The 48-hour access window is enforced by the HMAC token; the signed URL is just the final, brief hop to the bytes. So the platform only needs: a private bucket + keyless signBlob. Nothing app-specific.

--- a/docs/stackramp-yaml-reference.md
+++ b/docs/stackramp-yaml-reference.md
@@ -199,16 +199,58 @@ Whether the app needs a managed database. When enabled (Phase 2), the platform w
 
 | | |
 |---|---|
-| Type | `boolean` or `string` |
-| Values | `false`, `gcs` |
+| Type | `boolean`, `string`, or `object` |
+| Values | `false`, `gcs`, or a `{ buckets: [...] }` block |
 | Default | `false` |
 
-Whether the app needs persistent object storage. When `gcs` is set:
-- A GCS bucket named `{app_name}-data-{environment}` is provisioned
-- The Cloud Run service account is granted `roles/storage.objectAdmin`
-- `GCS_BUCKET` env var is automatically injected into the backend service
+Object storage. There are two forms, both supported:
 
-**Example:**
+**Scalar form (legacy, unchanged):** `storage: gcs` provisions a single bucket named `{app_name}-data-{environment}`, grants the Cloud Run runtime service account `roles/storage.objectAdmin`, and injects `GCS_BUCKET` into the backend. `storage: false` (the default) provisions nothing.
+
+**Block form (one or more named buckets):**
+
+```yaml
+storage:
+  buckets:
+    - name: downloads        # logical name -> env var BUCKET_DOWNLOADS
+      access: private        # private (default) | public
+      signed_urls: true      # grant the SA keyless V4 signBlob (no key file)
+      lifecycle_days: 0      # optional object TTL in days (0 = no rule)
+```
+
+For each entry in `buckets` the platform provisions a bucket named `{project}-{app}-{env}-{name}` with uniform bucket-level access, and:
+
+| Field | Default | Behaviour |
+|---|---|---|
+| `name` | *(required)* | Logical name. Lowercase slug. Injected as env var `BUCKET_<NAME_UPPER>` (hyphens become underscores, e.g. `user-uploads` -> `BUCKET_USER_UPLOADS`). Bucket resolves to `{project}-{app}-{env}-{name}`. |
+| `access` | `private` | `private` turns **public access prevention** ON (anonymous access is rejected). `public` leaves it `inherited`. |
+| `signed_urls` | `false` | When `true`, grants the runtime SA `roles/iam.serviceAccountTokenCreator` **on itself** so the backend can mint V4 signed URLs via `signBlob` with **no exported key file** (keyless signing). |
+| `lifecycle_days` | `0` | When `> 0`, adds an age-based **delete** lifecycle rule of that many days. `0` adds no rule. |
+
+The runtime SA is granted `roles/storage.objectAdmin` scoped to each bucket only.
+
+**Keyless signed URLs:** with `signed_urls: true`, application code generates V4 signed URLs without a downloaded service account key. In Go, construct the signer from the runtime credentials and let the IAM `signBlob` API do the signing (`storage.SignedURLOptions` with `GoogleAccessID` set to the runtime SA email and a `SignBytes`/IAM-credentials signer). No `GOOGLE_APPLICATION_CREDENTIALS` key file is needed.
+
+**Back-compat:** `storage: false` and `storage: gcs` continue to behave exactly as before. The block form is additive; mixing the scalar `gcs` form and the block form in one file is not supported (use one or the other).
+
+**Example (block form):**
+```yaml
+name: my-app
+
+backend:
+  language: go
+  dir: backend
+  port: 8080
+
+storage:
+  buckets:
+    - name: downloads
+      access: private
+      signed_urls: true
+      lifecycle_days: 2
+```
+
+**Example (legacy scalar form):**
 ```yaml
 name: my-app
 

--- a/docs/stackramp-yaml-reference.md
+++ b/docs/stackramp-yaml-reference.md
@@ -213,17 +213,17 @@ Object storage. There are two forms, both supported:
 storage:
   buckets:
     - name: downloads        # logical name -> env var BUCKET_DOWNLOADS
-      access: private        # private (default) | public
+      access: private        # private only — public is not yet supported
       signed_urls: true      # grant the SA keyless V4 signBlob (no key file)
       lifecycle_days: 0      # optional object TTL in days (0 = no rule)
 ```
 
-For each entry in `buckets` the platform provisions a bucket named `{project}-{app}-{env}-{name}` with uniform bucket-level access, and:
+For each entry in `buckets` the platform provisions a **private** bucket named `{project}-{app}-{env}-{name}` with uniform bucket-level access. The resolved name must be **63 characters or fewer** (the GCS limit); deploys with a longer name fail validation early, so keep logical names short. Each bucket has:
 
 | Field | Default | Behaviour |
 |---|---|---|
 | `name` | *(required)* | Logical name. Lowercase slug. Injected as env var `BUCKET_<NAME_UPPER>` (hyphens become underscores, e.g. `user-uploads` -> `BUCKET_USER_UPLOADS`). Bucket resolves to `{project}-{app}-{env}-{name}`. |
-| `access` | `private` | `private` turns **public access prevention** ON (anonymous access is rejected). `public` leaves it `inherited`. |
+| `access` | `private` | Only `private` is supported: **public access prevention** is enforced (anonymous access is rejected). `access: public` is reserved for a future release and is currently a hard validation error — public buckets / CDN fronting are out of scope. |
 | `signed_urls` | `false` | When `true`, grants the runtime SA `roles/iam.serviceAccountTokenCreator` **on itself** so the backend can mint V4 signed URLs via `signBlob` with **no exported key file** (keyless signing). |
 | `lifecycle_days` | `0` | When `> 0`, adds an age-based **delete** lifecycle rule of that many days. `0` adds no rule. |
 

--- a/platform-action/action.yml
+++ b/platform-action/action.yml
@@ -50,6 +50,9 @@ outputs:
   storage_type:
     description: "Storage type (gcs or false)"
     value: ${{ steps.parse.outputs.storage_type }}
+  storage_buckets:
+    description: "JSON array of storage.buckets configs ([] when none or scalar form). Each entry: {name, access, signed_urls, lifecycle_days}."
+    value: ${{ steps.parse.outputs.storage_buckets }}
   has_sso:
     description: "Whether SSO (IAP) is enabled for this app"
     value: ${{ steps.parse.outputs.has_sso }}
@@ -150,13 +153,44 @@ runs:
         HAS_DATABASE="false"
         [ "$DATABASE" != "false" ] && [ "$DATABASE" != "null" ] && HAS_DATABASE="true"
 
-        STORAGE=$(yq e '.storage // "false"' "$CONFIG")
-        if [ "$STORAGE" = "gcs" ]; then
-          HAS_STORAGE="true"
-          STORAGE_TYPE="gcs"
+        # storage: can be a scalar (false | gcs) for the legacy single bucket,
+        # or a block ({ buckets: [...] }) declaring one or more named buckets.
+        # Detect the block form by counting .storage.buckets entries. A scalar
+        # storage value yields an empty length, so default to 0 and treat any
+        # positive count as the block form. (Comparing the yq node tag, e.g.
+        # "!!seq", is avoided — the "!" trips shell history expansion.)
+        HAS_STORAGE="false"
+        STORAGE_TYPE="false"
+        STORAGE_BUCKETS="[]"
+        BUCKET_COUNT=$(yq e '.storage.buckets | length' "$CONFIG" 2>/dev/null)
+        [ -z "$BUCKET_COUNT" ] || [ "$BUCKET_COUNT" = "null" ] && BUCKET_COUNT=0
+        if [ "$BUCKET_COUNT" -gt 0 ]; then
+          # Block form: emit the buckets array as compact JSON for downstream
+          # Terraform consumption. Apply defaults (access=private, signed_urls=false,
+          # lifecycle_days=0) so the JSON is fully populated and self-describing.
+          STORAGE_BUCKETS=$(yq e -o=json -I=0 '
+            [.storage.buckets[] | {
+              "name": .name,
+              "access": (.access // "private"),
+              "signed_urls": (.signed_urls // false),
+              "lifecycle_days": (.lifecycle_days // 0)
+            }]
+          ' "$CONFIG")
+          # Validate every bucket has a non-empty name; abort early with a clear error.
+          if echo "$STORAGE_BUCKETS" | yq e -p=json '.[] | select(.name == null or .name == "")' - | grep -q .; then
+            echo "::error::Every storage.buckets entry must have a non-empty 'name'."
+            exit 1
+          fi
+          { [ -z "$STORAGE_BUCKETS" ] || [ "$STORAGE_BUCKETS" = "null" ]; } && STORAGE_BUCKETS="[]"
+          if [ "$STORAGE_BUCKETS" != "[]" ]; then
+            STORAGE_TYPE="gcs"
+          fi
         else
-          HAS_STORAGE="false"
-          STORAGE_TYPE="false"
+          STORAGE=$(yq e '.storage // "false"' "$CONFIG")
+          if [ "$STORAGE" = "gcs" ]; then
+            HAS_STORAGE="true"
+            STORAGE_TYPE="gcs"
+          fi
         fi
 
         FRONTEND_SSO=$(yq '.frontend.sso // false' "$CONFIG")
@@ -218,6 +252,7 @@ runs:
         echo "provider=$PROVIDER" >> $GITHUB_OUTPUT
         echo "has_storage=$HAS_STORAGE" >> $GITHUB_OUTPUT
         echo "storage_type=$STORAGE_TYPE" >> $GITHUB_OUTPUT
+        echo "storage_buckets=$STORAGE_BUCKETS" >> $GITHUB_OUTPUT
         echo "custom_domain=$CUSTOM_DOMAIN" >> $GITHUB_OUTPUT
         echo "has_sso=$HAS_SSO" >> $GITHUB_OUTPUT
         echo "migrate_command=$MIGRATE_COMMAND" >> $GITHUB_OUTPUT
@@ -237,7 +272,7 @@ runs:
         echo "Frontend: $FRONTEND_FRAMEWORK ($FRONTEND_DIR)"
         echo "Backend: $BACKEND_LANG ($BACKEND_DIR:$BACKEND_PORT)"
         echo "Database: $DATABASE"
-        echo "Storage: $STORAGE"
+        echo "Storage: type=$STORAGE_TYPE buckets=$STORAGE_BUCKETS"
         echo "SSO: $HAS_SSO"
         echo "Migrate: ${MIGRATE_COMMAND:-none}"
         echo "Provider: $PROVIDER"

--- a/platform-action/action.yml
+++ b/platform-action/action.yml
@@ -181,6 +181,48 @@ runs:
             echo "::error::Every storage.buckets entry must have a non-empty 'name'."
             exit 1
           fi
+
+          # Logical names must be unique. Terraform keys local.buckets by name, so
+          # duplicates silently collapse (last-wins) and drop a bucket with no error.
+          # Catch it here and name the offending logical bucket.
+          DUP_NAME=$(echo "$STORAGE_BUCKETS" | yq e -p=json -o=tsv '.[].name' - | sort | uniq -d | head -n1)
+          if [ -n "$DUP_NAME" ]; then
+            echo "::error::Duplicate storage.buckets name '$DUP_NAME'. Each bucket must have a unique logical 'name'."
+            exit 1
+          fi
+
+          # Public buckets are out of scope. access: public would otherwise produce a
+          # bucket that is NOT actually anonymously readable (uniform access stays on
+          # and allUsers is never granted), which is misleading. Reject it explicitly.
+          PUBLIC_NAME=$(echo "$STORAGE_BUCKETS" | yq e -p=json -o=tsv '.[] | select(.access == "public") | .name' - | head -n1)
+          if [ -n "$PUBLIC_NAME" ]; then
+            echo "::error::storage.buckets entry '$PUBLIC_NAME' sets access: public, which is not yet supported. All StackRamp buckets are private (public access prevention enforced). Remove the access field or set it to 'private'."
+            exit 1
+          fi
+
+          # GCS caps bucket names at 63 chars. The resolved name is
+          # {project}-{app}-{env}-{name}; a long project prefix can push it over,
+          # failing at terraform apply with an opaque GCS 400. Fail early here when
+          # the project id is known (STACKRAMP_PROJECT, injected by the platform
+          # workflow). The platform deploys to environments 'dev' and 'prod' from a
+          # single parse, so check against the longest ('prod', 4 chars): if it fits
+          # for prod it fits for dev. The Terraform precondition is the authoritative
+          # backstop for any env not covered here.
+          PROJECT_ID="${STACKRAMP_PROJECT:-}"
+          if [ -n "$PROJECT_ID" ]; then
+            WORST_ENV="prod"
+            while IFS= read -r LOGICAL; do
+              [ -z "$LOGICAL" ] && continue
+              RESOLVED="${PROJECT_ID}-${APP_NAME}-${WORST_ENV}-${LOGICAL}"
+              LEN=${#RESOLVED}
+              if [ "$LEN" -gt 63 ]; then
+                OVER=$((LEN - 63))
+                echo "::error::Resolved GCS bucket name '$RESOLVED' for bucket '$LOGICAL' is $LEN characters, $OVER over the 63-char GCS limit. Shorten the bucket 'name' or app name."
+                exit 1
+              fi
+            done < <(echo "$STORAGE_BUCKETS" | yq e -p=json -o=tsv '.[].name' -)
+          fi
+
           { [ -z "$STORAGE_BUCKETS" ] || [ "$STORAGE_BUCKETS" = "null" ]; } && STORAGE_BUCKETS="[]"
           if [ "$STORAGE_BUCKETS" != "[]" ]; then
             STORAGE_TYPE="gcs"

--- a/platform-action/schema.json
+++ b/platform-action/schema.json
@@ -105,7 +105,7 @@
                     "type": "string",
                     "enum": ["private", "public"],
                     "default": "private",
-                    "description": "private (default) enforces public access prevention. public leaves it inherited."
+                    "description": "Bucket access. Only 'private' (the default) is supported: public access prevention is enforced. 'public' is reserved for a future release and is currently rejected at validation time (public buckets / CDN fronting are out of scope)."
                   },
                   "signed_urls": {
                     "type": "boolean",

--- a/platform-action/schema.json
+++ b/platform-action/schema.json
@@ -77,6 +77,54 @@
         "fail_on_findings": { "type": "boolean", "default": true }
       }
     },
+    "storage": {
+      "description": "Object storage. Scalar forms (false | gcs) keep the legacy single-bucket behaviour. The object form declares one or more named private GCS buckets.",
+      "default": false,
+      "oneOf": [
+        { "type": "boolean" },
+        { "type": "string", "enum": ["gcs"] },
+        {
+          "type": "object",
+          "required": ["buckets"],
+          "additionalProperties": false,
+          "properties": {
+            "buckets": {
+              "type": "array",
+              "minItems": 1,
+              "items": {
+                "type": "object",
+                "required": ["name"],
+                "additionalProperties": false,
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "pattern": "^[a-z][a-z0-9-]*$",
+                    "description": "Logical bucket name. Injected as env var BUCKET_<NAME_UPPER>. Resolves to bucket gs://{project}-{app}-{env}-{name}."
+                  },
+                  "access": {
+                    "type": "string",
+                    "enum": ["private", "public"],
+                    "default": "private",
+                    "description": "private (default) enforces public access prevention. public leaves it inherited."
+                  },
+                  "signed_urls": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Grant the Cloud Run runtime SA token-creator on itself so the backend can mint keyless V4 signed URLs (signBlob, no key file)."
+                  },
+                  "lifecycle_days": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "default": 0,
+                    "description": "Age-based delete lifecycle rule in days. 0 = no rule."
+                  }
+                }
+              }
+            }
+          }
+        }
+      ]
+    },
     "quality": {
       "type": "object",
       "description": "Pulse code quality gates. Enabled by default.",

--- a/providers/gcp/terraform/platform/main.tf
+++ b/providers/gcp/terraform/platform/main.tf
@@ -253,13 +253,57 @@ resource "google_cloud_run_domain_mapping" "sso_frontend" {
   }
 }
 
-# ── GCS Data Bucket (optional) ────────────────────────────────────────────────
-# When storage: gcs is declared in stackramp.yaml, provisions a persistent
-# data bucket and grants the Cloud Run service account access.
+# ── GCS Buckets ───────────────────────────────────────────────────────────────
+# Two paths, both back-compatible:
+#
+#   1. Legacy single bucket — storage: gcs in stackramp.yaml sets has_storage.
+#      Keeps the original resource name (app_data) and bucket name
+#      ({app_name}-data-{env}) so existing apps see no destroy/recreate.
+#
+#   2. storage.buckets block — buckets_json carries an array of bucket configs.
+#      Provisioned with for_each keyed on logical name. Bucket name follows
+#      {project}-{app}-{env}-{name}. Each bucket grants the Cloud Run runtime SA
+#      objectAdmin scoped to that bucket, optional age-based lifecycle delete,
+#      and (when signed_urls) keyless V4 signing via serviceAccountTokenCreator.
+#
+# The Cloud Run runtime SA for backends is the project default compute SA. The
+# frontend_sa_email var is the SSO frontend proxy identity, NOT the backend
+# runtime identity, so it is deliberately not used here.
 
 data "google_project" "project" {
   project_id = var.platform_project
 }
+
+locals {
+  runtime_sa_email = "${data.google_project.project.number}-compute@developer.gserviceaccount.com"
+  runtime_sa_id    = "projects/${var.platform_project}/serviceAccounts/${local.runtime_sa_email}"
+
+  # Decode the storage.buckets block into a map keyed by logical name, applying
+  # defaults for omitted fields. access defaults to private; signed_urls and
+  # lifecycle_days default off.
+  bucket_list = jsondecode(var.buckets_json)
+  buckets = {
+    for b in local.bucket_list : b.name => {
+      name           = b.name
+      access         = try(b.access, "private")
+      signed_urls    = try(b.signed_urls, false)
+      lifecycle_days = try(b.lifecycle_days, 0)
+      bucket_name    = "${var.platform_project}-${var.app_name}-${var.environment}-${b.name}"
+    }
+  }
+
+  # Logical name -> resolved bucket name, for the env-var output the workflow
+  # turns into BUCKET_<NAME_UPPER> injections.
+  bucket_env = {
+    for k, v in local.buckets : k => v.bucket_name
+  }
+
+  # Any block-form bucket asking for keyless V4 signed URLs needs the runtime SA
+  # granted token-creator on itself. One grant covers all such buckets.
+  any_signed_urls = length([for k, v in local.buckets : k if v.signed_urls]) > 0
+}
+
+# ── Legacy single bucket (storage: gcs) ───────────────────────────────────────
 
 resource "google_storage_bucket" "app_data" {
   count         = var.has_storage ? 1 : 0
@@ -275,12 +319,59 @@ resource "google_storage_bucket" "app_data" {
   }
 }
 
-# Grant Cloud Run service account (default compute SA) objectAdmin on the bucket
+# Grant Cloud Run runtime SA (default compute SA) objectAdmin on the legacy bucket
 resource "google_storage_bucket_iam_member" "app_data_run" {
   count  = var.has_storage ? 1 : 0
   bucket = google_storage_bucket.app_data[0].name
   role   = "roles/storage.objectAdmin"
-  member = "serviceAccount:${data.google_project.project.number}-compute@developer.gserviceaccount.com"
+  member = "serviceAccount:${local.runtime_sa_email}"
+}
+
+# ── storage.buckets block ─────────────────────────────────────────────────────
+
+resource "google_storage_bucket" "app_bucket" {
+  for_each      = local.buckets
+  name          = each.value.bucket_name
+  project       = var.platform_project
+  location      = var.region
+  force_destroy = false
+
+  uniform_bucket_level_access = true
+  public_access_prevention    = each.value.access == "public" ? "inherited" : "enforced"
+
+  dynamic "lifecycle_rule" {
+    for_each = each.value.lifecycle_days > 0 ? [each.value.lifecycle_days] : []
+    content {
+      action {
+        type = "Delete"
+      }
+      condition {
+        age = lifecycle_rule.value
+      }
+    }
+  }
+
+  lifecycle {
+    prevent_destroy = false
+  }
+}
+
+# Grant the Cloud Run runtime SA objectAdmin scoped to each block-form bucket
+resource "google_storage_bucket_iam_member" "app_bucket_run" {
+  for_each = local.buckets
+  bucket   = google_storage_bucket.app_bucket[each.key].name
+  role     = "roles/storage.objectAdmin"
+  member   = "serviceAccount:${local.runtime_sa_email}"
+}
+
+# Keyless V4 signed URLs: grant the runtime SA token-creator on ITSELF so the
+# backend can call signBlob with no exported key file. Granted once when any
+# block-form bucket sets signed_urls: true.
+resource "google_service_account_iam_member" "runtime_sa_token_creator" {
+  count              = local.any_signed_urls ? 1 : 0
+  service_account_id = local.runtime_sa_id
+  role               = "roles/iam.serviceAccountTokenCreator"
+  member             = "serviceAccount:${local.runtime_sa_email}"
 }
 
 # ── Per-App Postgres Database (optional) ─────────────────────────────────────

--- a/providers/gcp/terraform/platform/main.tf
+++ b/providers/gcp/terraform/platform/main.tf
@@ -262,9 +262,11 @@ resource "google_cloud_run_domain_mapping" "sso_frontend" {
 #
 #   2. storage.buckets block — buckets_json carries an array of bucket configs.
 #      Provisioned with for_each keyed on logical name. Bucket name follows
-#      {project}-{app}-{env}-{name}. Each bucket grants the Cloud Run runtime SA
-#      objectAdmin scoped to that bucket, optional age-based lifecycle delete,
-#      and (when signed_urls) keyless V4 signing via serviceAccountTokenCreator.
+#      {project}-{app}-{env}-{name}. All buckets are private (public access
+#      prevention enforced) — public buckets are out of scope. Each bucket
+#      grants the Cloud Run runtime SA objectAdmin scoped to that bucket,
+#      optional age-based lifecycle delete, and (when signed_urls) keyless V4
+#      signing via serviceAccountTokenCreator.
 #
 # The Cloud Run runtime SA for backends is the project default compute SA. The
 # frontend_sa_email var is the SSO frontend proxy identity, NOT the backend
@@ -279,13 +281,13 @@ locals {
   runtime_sa_id    = "projects/${var.platform_project}/serviceAccounts/${local.runtime_sa_email}"
 
   # Decode the storage.buckets block into a map keyed by logical name, applying
-  # defaults for omitted fields. access defaults to private; signed_urls and
-  # lifecycle_days default off.
+  # defaults for omitted fields. signed_urls and lifecycle_days default off.
+  # Buckets are always private — public access is out of scope and is rejected
+  # earlier in platform-action/action.yml, so no access field is carried here.
   bucket_list = jsondecode(var.buckets_json)
   buckets = {
     for b in local.bucket_list : b.name => {
       name           = b.name
-      access         = try(b.access, "private")
       signed_urls    = try(b.signed_urls, false)
       lifecycle_days = try(b.lifecycle_days, 0)
       bucket_name    = "${var.platform_project}-${var.app_name}-${var.environment}-${b.name}"
@@ -337,7 +339,7 @@ resource "google_storage_bucket" "app_bucket" {
   force_destroy = false
 
   uniform_bucket_level_access = true
-  public_access_prevention    = each.value.access == "public" ? "inherited" : "enforced"
+  public_access_prevention    = "enforced"
 
   dynamic "lifecycle_rule" {
     for_each = each.value.lifecycle_days > 0 ? [each.value.lifecycle_days] : []
@@ -353,6 +355,15 @@ resource "google_storage_bucket" "app_bucket" {
 
   lifecycle {
     prevent_destroy = false
+
+    # GCS bucket names are capped at 63 characters. The resolved name is
+    # {project}-{app}-{env}-{logical}, so a long project prefix can overflow
+    # and fail at apply with an opaque GCS 400. Fail early with a clear message
+    # naming the logical bucket, the resolved name, and its length.
+    precondition {
+      condition     = length(each.value.bucket_name) <= 63
+      error_message = "GCS bucket name for logical bucket '${each.value.name}' is ${length(each.value.bucket_name)} characters (max 63): '${each.value.bucket_name}'. Shorten the bucket 'name', app name, or environment."
+    }
   }
 }
 

--- a/providers/gcp/terraform/platform/outputs.tf
+++ b/providers/gcp/terraform/platform/outputs.tf
@@ -18,8 +18,17 @@ output "backend_url" {
 }
 
 output "storage_bucket" {
-  description = "GCS bucket name for app data (empty if not enabled)"
+  description = "Legacy single GCS bucket name for storage: gcs (empty if not enabled). Back-compat only."
   value       = var.has_storage ? google_storage_bucket.app_data[0].name : ""
+}
+
+output "bucket_env_json" {
+  description = <<-EOT
+    JSON object mapping logical bucket name -> resolved GCS bucket name for the
+    storage.buckets block. The backend deploy job turns each entry into a
+    BUCKET_<NAME_UPPER> env var. Empty object "{}" when no block-form buckets.
+  EOT
+  value       = jsonencode(local.bucket_env)
 }
 
 output "database_secret_name" {

--- a/providers/gcp/terraform/platform/variables.tf
+++ b/providers/gcp/terraform/platform/variables.tf
@@ -44,9 +44,21 @@ variable "has_backend" {
 }
 
 variable "has_storage" {
-  description = "Whether to provision a GCS bucket for this app"
+  description = "Back-compat: whether to provision the legacy single GCS data bucket (storage: gcs). Superseded by buckets_json for the storage.buckets block form."
   type        = bool
   default     = false
+}
+
+variable "buckets_json" {
+  description = <<-EOT
+    JSON-encoded array of bucket configs from the storage.buckets block in
+    stackramp.yaml. Each entry: { name, access, signed_urls, lifecycle_days }.
+    Default "[]" = no block-form buckets. Independent of has_storage, which
+    drives the legacy storage: gcs single-bucket path for back-compat.
+    Example: [{"name":"downloads","access":"private","signed_urls":true,"lifecycle_days":0}]
+  EOT
+  type        = string
+  default     = "[]"
 }
 
 variable "has_database" {

--- a/stackramp.yaml.example
+++ b/stackramp.yaml.example
@@ -24,8 +24,8 @@ database: false        # false | postgres | mysql (Phase 2)
 #
 # storage:             # block form — one or more private GCS buckets
 #   buckets:
-#     - name: downloads        # -> env var BUCKET_DOWNLOADS, bucket {project}-{app}-{env}-downloads
-#       access: private        # private (default) | public
+#     - name: downloads        # -> env var BUCKET_DOWNLOADS, bucket {project}-{app}-{env}-downloads (<= 63 chars)
+#       access: private        # private only — public is not yet supported
 #       signed_urls: true      # keyless V4 signed URLs (signBlob, no key file)
 #       lifecycle_days: 0      # optional delete-after-N-days (0 = no rule)
 

--- a/stackramp.yaml.example
+++ b/stackramp.yaml.example
@@ -20,7 +20,14 @@ backend:
 
 database: false        # false | postgres | mysql (Phase 2)
 
-# storage: gcs         # false | gcs — provisions a GCS bucket + injects GCS_BUCKET env var
+# storage: gcs         # false | gcs — legacy single bucket, injects GCS_BUCKET env var
+#
+# storage:             # block form — one or more private GCS buckets
+#   buckets:
+#     - name: downloads        # -> env var BUCKET_DOWNLOADS, bucket {project}-{app}-{env}-downloads
+#       access: private        # private (default) | public
+#       signed_urls: true      # keyless V4 signed URLs (signBlob, no key file)
+#       lifecycle_days: 0      # optional delete-after-N-days (0 = no rule)
 
 # ── Security & Quality (both enabled by default — no config needed) ──────────
 # security:              # Guardian security scanning


### PR DESCRIPTION
## Task

Requirement: `docs/requirements/stackramp-gcs-storage.md` — GCS bucket support in `stackramp.yaml`. Priority: high (blocks the AI Security Posture paid-download launch).

## Analyse

`storage:` was a scalar only (`false` / `gcs`), provisioning a single `app_data` bucket gated on `var.has_storage` with one `objectAdmin` grant. The pipeline runs action.yml (yq parse) → platform.yml (`-var` into Terraform, reads `storage_bucket` output) → `_backend.yml` (injects `GCS_BUCKET`). The Cloud Run backend runtime identity is the **default compute SA** (`{project_number}-compute@developer.gserviceaccount.com`), not `frontend_sa_email` (that is the SSO proxy identity).

## Architect

Model the block as a single `buckets_json` string var (JSON-decoded in Terraform into a `for_each` map keyed on logical name). Passing JSON as one quoted `-var` avoids HCL-object-literal quoting pain on the shell command line and matches what the action emits anyway. Back-compat: keep the legacy `has_storage` / `app_data` resource and `storage_bucket` output untouched; the block form is purely additive via new resources (`app_bucket`, `app_bucket_run`, `runtime_sa_token_creator`).

## Changes

- `platform-action/action.yml`: detect block form by counting `.storage.buckets` (avoids the `!!seq`/`!!map` tag literal which trips shell history expansion), emit `storage_buckets` JSON output with defaults applied; validate every bucket has a non-empty name. Legacy scalar path unchanged.
- `platform-action/schema.json`: `storage` becomes a `oneOf` (boolean | `"gcs"` | object with `buckets[]`), each bucket validated for name/access/signed_urls/lifecycle_days.
- `providers/gcp/terraform/platform/`:
  - `variables.tf`: add `buckets_json` (default `"[]"`).
  - `main.tf`: `jsondecode` → `for_each` map; per-bucket `uniform_bucket_level_access`, `public_access_prevention` (enforced when private), conditional `lifecycle_rule` delete, per-bucket `objectAdmin`. Single `google_service_account_iam_member` granting `serviceAccountTokenCreator` on the runtime SA to itself when any bucket sets `signed_urls`. Legacy `app_data` path preserved.
  - `outputs.tf`: add `bucket_env_json` (logical name → bucket name map); keep `storage_bucket`.
- `.github/workflows/platform.yml`: thread `storage_buckets` through parse-config, pass `buckets_json` as a separate quoted `-var` (dev + prod), read back `bucket_env_json`, forward to both backend deploy jobs.
- `.github/workflows/_backend.yml`: new `bucket_env_json` input; inject one `BUCKET_<NAME_UPPER>` per bucket (hyphens → underscores), alongside the back-compat `GCS_BUCKET`.
- Docs: `docs/stackramp-yaml-reference.md`, `INTEGRATION.md`, `stackramp.yaml.example` updated with the block, env-var convention, keyless signBlob note, lifecycle, and back-compat statement.

## Tests

This repo has no Go test suite; validation was done against the layers that can be exercised locally (CI/GCP cannot be):

- `terraform fmt -check` clean and `terraform validate` Success on the platform module.
- `terraform console` confirmed the `jsondecode` + `try()` defaults produce the expected per-bucket map (private/false/0 defaults, explicit overrides preserved, `bucket_name` composed).
- yq parsing logic exercised against 5 sample stackramp.yaml inputs (absent / `false` / `gcs` / block-with-defaults / block-missing-name): scalar paths unchanged, block form emits correct JSON with defaults, missing-name errors with exit 1.
- `_backend.yml` `BUCKET_<NAME>` injection tested with jq: `downloads`→`BUCKET_DOWNLOADS`, `user-uploads`→`BUCKET_USER_UPLOADS`, empty `{}` skipped.
- `schema.json` validated as JSON; all three workflow/action YAML files parse cleanly.

**Could NOT be verified locally (reviewer/deploy must check):** actual GCP provisioning; that the runtime SA mints a working V4 signed URL with no key file (the `signBlob` round-trip); public access prevention rejecting anonymous reads; `BUCKET_<NAME>` present in the running service; that an existing `storage: gcs` app shows no destroy/recreate on `app_data`.

## Reuse

Builds on the existing storage pipeline (action → platform.yml → terraform → _backend.yml) and mirrors the `platform_secrets` env-injection pattern. Reuses the existing `data.google_project.project` and the established `for_each`/`count` resource gating style already in the module.