### PR TITLE
fix(bootstrap): grant cicd SA serviceAccountAdmin for signed_urls buckets

### DIFF
--- a/providers/gcp/terraform/bootstrap/main.tf
+++ b/providers/gcp/terraform/bootstrap/main.tf
@@ -92,6 +92,12 @@ resource "google_project_iam_member" "platform_roles" {
     "roles/firebase.admin",
     "roles/secretmanager.admin",
     "roles/iam.serviceAccountUser",
+    # serviceAccountAdmin lets the deployer get/set IAM policy on service
+    # accounts. Required by the storage.buckets signed_urls path: the platform
+    # binds roles/iam.serviceAccountTokenCreator on the runtime SA *to itself*
+    # for keyless V4 signing, and that binding reads+writes the SA's IAM policy.
+    # Without this, terraform apply 403s on iam.serviceAccounts.getIamPolicy.
+    "roles/iam.serviceAccountAdmin",
     "roles/cloudsql.admin",
     "roles/storage.admin",
     "roles/dns.admin",


### PR DESCRIPTION
## Problem

The `storage.buckets` feature shipped, but apps declaring a bucket with `signed_urls: true` fail at `terraform apply` with:

```
Error 403: Permission 'iam.serviceAccounts.getIamPolicy' denied on
serviceAccounts/<NUM>-compute@developer.gserviceaccount.com
```

The signed_urls path binds `roles/iam.serviceAccountTokenCreator` on the runtime compute SA **to itself** (keyless V4 signBlob). `google_service_account_iam_member` reads+writes the SA's IAM policy, but the deployer (`stackramp-cicd-sa`) only had `roles/iam.serviceAccountUser` — which can't get/set IAM policy on an SA.

## Fix

Add `roles/iam.serviceAccountAdmin` to the platform CI/CD SA's project roles. Consistent with the SA's existing posture (it already holds storage.admin, secretmanager.admin, run.admin, etc).

## Apply

Bootstrap is applied once per env. After merge, run `terraform apply` on bootstrap for `bj-platform-dev` (and prod). To unblock the in-flight AISP launch immediately without a full bootstrap apply:

```
gcloud projects add-iam-policy-binding bj-platform-dev \
  --member="serviceAccount:stackramp-cicd-sa@bj-platform-dev.iam.gserviceaccount.com" \
  --role="roles/iam.serviceAccountAdmin"
```

First surfaced by `aiposture` declaring a `downloads` bucket for the paid Playbook fulfilment flow.