### PR TITLE
[gopher] docs: add CHANGELOG (agentops-103)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+
+All notable changes to this project are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+- **IAP user identity forwarding** (#33) — the SSO proxy now forwards the authenticated caller's identity to the backend via two re-keyed pass-through headers, `X-Stackramp-User-Email` and `X-Stackramp-User-Id`, sourced from IAP's `X-Goog-Authenticated-User-*` headers with the `accounts.google.com:` prefix stripped. Backends opt in to user-aware logic by reading the new headers; existing backends that ignore them are unaffected. Re-keying avoids the Cloud Run auth-layer collision that requires the proxy to strip the original IAP JWT headers.
+- **GCS bucket support in `stackramp.yaml`** (#34) — the `storage:` key now accepts a block form, `storage.buckets`, that provisions one GCS bucket per entry and injects a `BUCKET_<NAME>` env var into the Cloud Run service (for example, a `downloads` bucket exposes `BUCKET_DOWNLOADS`). The runtime service account is granted `roles/storage.objectAdmin` on each provisioned bucket. The existing scalar forms `storage: false` and `storage: gcs` are unchanged and remain back-compatible; use the scalar form or the block form, not both in one file.
+
+### Fixed
+- **Bootstrap signed-URL IAM permission** (#35) — the platform CI/CD service account is now granted `roles/iam.serviceAccountAdmin` during bootstrap so the keyless V4 signed-URL IAM binding can be applied to buckets declared under `storage.buckets`. Resolves a bootstrap failure that occurred when a `storage.buckets` block was present.


### PR DESCRIPTION
## Task
agentops-103 — Add CHANGELOG.md to paaga (StackRamp) covering PRs #33, #34 and the bootstrap fix.
File: ~/code/newlife/tasks/agentops/agentops-103.md

## Analyse
paaga (remote `bobbydeveaux/stackramp`) had no `CHANGELOG.md`. Three substantive changes have merged to main since the last documented state: PR #33 (IAP user identity forwarding via `X-Stackramp-*` headers), PR #34 (`storage.buckets` GCS block support), and PR #35 (bootstrap grant of `serviceAccountAdmin` for the keyless V4 signed-URL IAM binding). Note: the bootstrap fix landed as PR #35 (merged 2026-06-17), so it is documented as merged rather than the task body's outdated "on local branch" framing.

## Architect
Single new file `CHANGELOG.md` at repo root, keepachangelog.com format with the standard Keep-a-Changelog + SemVer preamble (mirrored verbatim from `aisecurityposture/CHANGELOG.md`). One `[Unreleased]` section: `Added` (PR #33, PR #34) and `Fixed` (PR #35). Each entry uses a bold feature name, parenthetical PR number, and a user-visible sentence matching the wording in `INTEGRATION.md`. No version bump (per acceptance criteria).

## Changes
- `CHANGELOG.md` (new) — backfills IAP forwarding (#33), GCS bucket block support (#34), bootstrap signed-URL IAM fix (#35).

## Tests
Docs-only change. No Go code touched, so `go build`/`go test`/`go vet` are not applicable to this diff. The repo CI Quality gate still runs on the PR.

## Reuse
- Format reference: `aisecurityposture/CHANGELOG.md` and `cerebra/CHANGELOG.md` (verbatim header + Added/Fixed headings).
- Feature wording sourced from `paaga/INTEGRATION.md` and the PR #33/#34/#35 descriptions.
